### PR TITLE
feat: port email template engine from CustomEmails.cs (#27)

### DIFF
--- a/.speckit/plans/issue-27.md
+++ b/.speckit/plans/issue-27.md
@@ -1,0 +1,176 @@
+# Plan: Email Templates — Port CustomEmails.cs Template Logic
+
+**Issue:** #27  
+**Spec:** `.speckit/specs/issue-27.md`  
+**Status:** CLEAN
+
+---
+
+## Architecture Decision
+
+`EmailService` lives in `FlyITA.Core` and can't access `IWebHostEnvironment` for file paths. Introduce `IEmailTemplateLoader` (interface in Core, implementation in Web) to abstract template loading:
+- Checks local files first (`Templates/` folder)
+- Falls back to sidecar (`IPCentralDataAccess.GetEmailTemplateAsync()`)
+
+This replaces the direct `_dataAccess.GetEmailTemplateAsync()` calls in `EmailService`.
+
+## Implementation Order
+
+### Phase A: Template Infrastructure
+
+**A1. Create `IEmailTemplateLoader` interface**
+- File: `src/FlyITA.Core/Interfaces/IEmailTemplateLoader.cs`
+- Method: `Task<string?> LoadTemplateAsync(string templateName)`
+
+**A2. Create `FileEmailTemplateLoader` implementation**
+- File: `src/FlyITA.Web/Services/FileEmailTemplateLoader.cs`
+- Inject `IWebHostEnvironment` and `IPCentralDataAccess` and `IContextManager`
+- Strategy: check `ContentRootPath/Templates/{templateName}` → if exists, read file → else fall back to `_dataAccess.GetEmailTemplateAsync(templateName, contextManager.ProgramID)`
+- Register in DI as scoped (needs `IContextManager` which is scoped)
+- Add `NullEmailTemplateLoader` to `Core/DependencyInjection.cs` (follows existing TryAdd pattern)
+
+**A2b. Update `Core/DependencyInjection.cs`**
+- Add `services.TryAddScoped<IEmailTemplateLoader, NullEmailTemplateLoader>()` 
+- `NullEmailTemplateLoader` returns null (same pattern as NullPCentralDataAccess)
+
+**A3. Copy template files**
+- Copy `src/FlyITA/configuration/TravelerProfiler.html` → `src/FlyITA.Web/Templates/TravelerProfiler.html`
+- Copy `src/FlyITA/configuration/VacationTravelRequest.html` → `src/FlyITA.Web/Templates/VacationTravelRequest.html`
+- Mark as `Content` / `CopyToOutputDirectory: PreserveNewest` in `.csproj`
+
+**A4. Update `appsettings.json` with template paths**
+- Set `Email:TravelerProfileTemplate` → `TravelerProfiler.html`
+- Set `Email:VacationTravelRequestTemplate` → `VacationTravelRequest.html`
+
+### Phase B: Email Template Engine (Token Replacement)
+
+**B1. Create `EmailTemplateEngine` in Core**
+- File: `src/FlyITA.Core/Services/EmailTemplateEngine.cs`
+- Static/utility class — pure string operations, no dependencies
+- Methods:
+  - `ReplaceParticipantTokens(string body, Dictionary<string, object?> participant)` — all `<<...>>` participant tokens
+  - `ReplaceProgramTokens(string body, Dictionary<string, object?> program)` — all `[PROGRAM_...]` tokens
+  - `ReplaceFormFieldTokens(string body, Dictionary<string, string> formValues)` — all `[FieldName]` tokens from form data
+  - `ProcessRepeatingBlock(string body, string startTag, string endTag, List<Dictionary<string, string>> items, Dictionary<string, string> tokenMap)` — generic block processor for guest/passenger/frequent flyer blocks
+  - `ReplaceCustomFieldTokens(string body, Dictionary<string, string> customFields)` — `<<CustomField.{name}>>` pattern
+
+**B2. Update `EmailService` to use `IEmailTemplateLoader` and `EmailTemplateEngine`**
+- File: `src/FlyITA.Core/Services/EmailService.cs`
+- Add `IEmailTemplateLoader` to constructor (alongside existing `IConfiguration`, `IPCentralDataAccess`, `ISmtpClient`, `IContextManager`)
+- Replace `_dataAccess.GetEmailTemplateAsync()` calls with `_templateLoader.LoadTemplateAsync()`
+- Replace hand-coded 9-token `ReplacePlaceholdersAsync()` with calls to `EmailTemplateEngine` methods
+- Keep `IConfiguration` for non-template config (addresses, subjects for standard emails)
+- Add full token replacement for standard emails (participant + program data from sidecar)
+
+### Phase C: Vacation Email (Template-Based)
+
+**C1. Create `VacationEmailData` model**
+- File: `src/FlyITA.Core/Models/VacationEmailData.cs`
+- Email routing fields: `ToEmail`, `FromEmail`, `Subject` (page passes these from `EmailOptions`, since `EmailService` in Core can't access Web-layer options)
+- Fields matching legacy form tokens: NameOfPersonRequesting, GeneralAndPassengerEmail, PhoneNumber, DepartureCity, PreferredAirline, DestinationsInterestedIn, PreferredDatesOfTravel, DestinationsNotInterestedIn, VacationDetails, ImportantAmenities, RoomsNeeded
+- Nested list: `List<PassengerData>` (FirstName, LastName, BirthDate, Gender, PassportNumber, PassportExpirationDate)
+- Nested list: `List<FrequentFlyerData>` (Airline, Number)
+
+**C2. Add `SendVacationRequestEmailAsync` to `IEmailService` / `EmailService`**
+- Load `VacationTravelRequest.html` template via `IEmailTemplateLoader`
+- Replace form field tokens using `EmailTemplateEngine.ReplaceFormFieldTokens()`
+- Process `<passengerinfoi>...</passengerinfoi>` repeating block
+- Process `<frequentflyerti>...</frequentflyerti>` repeating block
+- Send via `ISmtpClient`
+
+**C3. Wire `Vacation.cshtml.cs` to use `IEmailService`**
+- Replace `BuildEmailBody()` hardcoded HTML + direct `ISmtpClient` usage
+- Inject `IEmailService` instead of `ISmtpClient` directly
+- Build `VacationEmailData` from form properties
+- Call `SendVacationRequestEmailAsync(data)`
+- Remove `SendVacationRequestEmailAsync` and `BuildEmailBody` private methods from page model
+
+### Phase D: Traveler Profile Email (Template-Based)
+
+**D1. Create `TravelerProfileEmailData` model**
+- File: `src/FlyITA.Core/Models/TravelerProfileEmailData.cs`
+- Email routing fields: `ToEmail`, `FromEmail`, `Subject` (same pattern as VacationEmailData)
+- Fields matching legacy form tokens: all 30+ fields from `Travelerprofileinformation.aspx.cs`
+- Nested lists for repeating blocks: FrequentFlyers, HotelMemberships, RentalCarMemberships
+
+**D2. Add `SendTravelerProfileFormEmailAsync` to `IEmailService` / `EmailService`**
+- Load `TravelerProfiler.html` template
+- Replace form field tokens
+- Process repeating blocks (frequentflyerti, hotelclubmembershipsti, rentalcarmembershipsti)
+- Send via `ISmtpClient`
+
+**D3. Wire `TravelerProfile.cshtml.cs` to send email on submit**
+- Inject `IEmailService`
+- In `OnPostAsync`, after successful save, build `TravelerProfileEmailData` from form properties
+- Call `SendTravelerProfileFormEmailAsync(data)`
+
+### Phase E: Tests
+
+**E1. Unit tests for `EmailTemplateEngine`**
+- File: `tests/FlyITA.Core.Tests/Services/EmailTemplateEngineTests.cs`
+- Test each replacement method: participant tokens, program tokens, form field tokens, custom field tokens
+- Test repeating block processor with 0, 1, multiple items
+- Test block markers removed even when no data
+
+**E2. Unit tests for `FileEmailTemplateLoader`**
+- File: `tests/FlyITA.Web.Tests/Services/FileEmailTemplateLoaderTests.cs`
+- Test file exists → returns content
+- Test file missing → falls back to sidecar
+- Test sidecar also returns null → returns null
+
+**E3. Update existing `EmailServiceTests`**
+- File: `tests/FlyITA.Core.Tests/Services/EmailServiceTests.cs`
+- Update to mock `IEmailTemplateLoader` instead of `IPCentralDataAccess.GetEmailTemplateAsync`
+- Add tests for vacation email and traveler profile email methods
+- Verify correct token replacement in email body
+
+**E4. Page model tests**
+- Update Vacation page tests to verify `IEmailService` is called (not `ISmtpClient` directly)
+- Add TravelerProfile email test
+
+### Phase F: Cleanup & Verify
+
+**F1. Remove unused imports/code**
+- Remove `ISmtpClient` injection from Vacation page model (now uses IEmailService)
+- Remove `BuildEmailBody()` from Vacation page model
+- Clean up old `ReplacePlaceholdersAsync` from EmailService (replaced by EmailTemplateEngine)
+
+**F2. Full build + test**
+- `dotnet build FlyITA.Modern.sln` — zero warnings
+- `dotnet test FlyITA.Modern.sln --filter "FullyQualifiedName!~E2E"` — all pass
+
+## File Change Summary
+
+| Action | File |
+|--------|------|
+| CREATE | `src/FlyITA.Core/Interfaces/IEmailTemplateLoader.cs` |
+| CREATE | `src/FlyITA.Core/Services/EmailTemplateEngine.cs` |
+| CREATE | `src/FlyITA.Core/Models/VacationEmailData.cs` |
+| CREATE | `src/FlyITA.Core/Models/TravelerProfileEmailData.cs` |
+| MODIFY | `src/FlyITA.Core/Interfaces/IEmailService.cs` |
+| MODIFY | `src/FlyITA.Core/Services/EmailService.cs` |
+| MODIFY | `src/FlyITA.Core/DependencyInjection.cs` |
+| CREATE | `src/FlyITA.Web/Services/FileEmailTemplateLoader.cs` |
+| COPY   | `src/FlyITA.Web/Templates/TravelerProfiler.html` |
+| COPY   | `src/FlyITA.Web/Templates/VacationTravelRequest.html` |
+| MODIFY | `src/FlyITA.Web/Pages/Vacation.cshtml.cs` |
+| MODIFY | `src/FlyITA.Web/Pages/TravelerProfile.cshtml.cs` |
+| MODIFY | `src/FlyITA.Web/Program.cs` (register FileEmailTemplateLoader) |
+| MODIFY | `src/FlyITA.Web/appsettings.json` |
+| CREATE | `tests/FlyITA.Core.Tests/Services/EmailTemplateEngineTests.cs` |
+| CREATE | `tests/FlyITA.Web.Tests/Services/FileEmailTemplateLoaderTests.cs` |
+| MODIFY | `tests/FlyITA.Core.Tests/Services/EmailServiceTests.cs` |
+
+## Dependencies
+
+```
+A1 → A2 → A3 → A4
+     ↓
+B1 → B2 ──────────→ C1 → C2 → C3
+                     D1 → D2 → D3
+                     E1 → E2 → E3 → E4 → F1 → F2
+```
+
+## Package Changes
+
+None — all needed packages already present.

--- a/.speckit/specs/issue-27.md
+++ b/.speckit/specs/issue-27.md
@@ -1,0 +1,206 @@
+# Spec: Email Templates — Port CustomEmails.cs Template Logic
+
+**Issue:** #27  
+**Epic:** #25 — Post-Migration: Integration Wiring & DevOps  
+**Status:** CLEAN
+
+---
+
+## Problem Statement
+
+The legacy `CustomEmails.cs` (815 lines) provides template-based email sending: load HTML templates from disk, replace 40+ placeholder tokens with participant/program/form data, process repeating guest blocks, and send via SMTP. The modern app has an `EmailService.cs` that is incomplete (only 9 of 40+ tokens, no guest blocks, no custom fields, templates fetched from sidecar which returns empty). The modern Vacation page sends email with hardcoded HTML instead of templates. The modern TravelerProfile page doesn't send email at all.
+
+## Legacy Behavior (Source of Truth)
+
+### Email Types
+
+| Email Type | Legacy Method | Template File | Trigger | Data Source |
+|-----------|--------------|---------------|---------|-------------|
+| Registration Confirmation | `CustomEmails.SendRegistrationConfirmation()` | `RegistrationConfirmationEmail.html` | Registration complete | PCentralLib participant/program |
+| Logon Credentials | `CustomEmails.SendLogonCredentials()` | `LogonCredentialsEmail.html` | Login created | PCentralLib participant/program |
+| Forgot Password | `CustomEmails.SendForgotPasswordCredentials()` | `SeamlessLogonCredentialsEmail.html` | Password reset | PCentralLib participant/program |
+| Traveler Profile (3rd party) | `CustomEmails.formatAndSendThirdPartyEmail()` | `TravelerProfiler.html` | TravelerProfile form submit | PCentralLib + form fields |
+| Vacation Request | `vacation.aspx.cs.SendTravelerProfileEmail()` | `VacationTravelRequest.html` | Vacation form submit | Form fields only |
+
+### Template Loading
+
+Legacy loads templates from **files on disk** in `configuration/` folder:
+- Path configured in `WebRegistration.config` (e.g., `configuration/TravelerProfiler.html`)
+- Loaded via `Utilities.LoadFileContent()` which calls `File.OpenText(MapPath(path))`
+
+### Token Replacement — Standard Emails
+
+These tokens are replaced in body AND subject for standard emails (registration, logon, forgot password):
+
+```
+[PARTICIPANT_NAME], [PARTICIPANT_EMAIL], [PARTICIPANT_USERNAME], [PARTICIPANT_PASSWORD]
+[FIRSTNAME], [LASTNAME]
+[PROGRAM_NAME], [PROGRAM_800NBR], [PROGRAM_HQNAME], [PROGRAM_URL], [PROGRAM_EMAIL]
+```
+
+Data from: `PCentralParticipant.GetByID()`, `PCentralProgram.GetByID()` — available via sidecar.
+
+### Token Replacement — Third-Party Emails (TravelerProfile)
+
+In addition to standard tokens, `formatAndSendThirdPartyEmail()` also replaces:
+- **Profile tokens**: `<<LegalFirstName>>`, `<<LegalMiddleName>>`, `<<LegalLastName>>`, `<<DateOfBirth>>`, `<<Gender>>`, `<<EmailAddress>>`
+- **Contact tokens**: `<<BusinessPhone>>`, `<<BusinessFax>>`, `<<MobilePhone>>`, `<<HomePhone>>`
+- **Travel tokens**: `<<TransportationType>>`, `<<TravelDates>>`, `<<PrefHomeDepartureTime>>`, `<<PrefDestDepartureTime>>`, `<<PrefAirline>>`, `<<PrefHomeDepartureCity>>`, `<<DriveTime>>`, `<<SeatPreference>>`, `<<AirRemarks>>`, `<<FrequentFlyerNumber>>`
+- **Hotel tokens**: `<<CheckInDate>>`, `<<CheckOutDate>>`
+- **Special tokens**: `<<Wheelchair>>`, `<<SpecialMeal>>`
+- **Custom field tokens**: `<<CustomField.{FieldName}>>` — dynamically replaced from DB
+- **Guest tokens**: `<<GLegalFirstName>>`, `<<GLegalMiddleName>>`, `<<GLegalLastName>>`, etc.
+
+Data from: `PCentralParticipant`, `PCentralPersonContactNumber`, `PCentralAirPreference`, `PCentralProgramCustomField` — all available via sidecar endpoints.
+
+### Token Replacement — Vacation Page (Form Fields)
+
+`vacation.aspx.cs` does its OWN token replacement from form fields (NOT from PCentralLib):
+
+```
+[NameofPersonRequesting], [GeneralandPassengerEmail], [PhoneNumber]
+[PassengerFirstName], [PassengerLastName], [BirthDate], [Gender]
+[PassportNumber], [PassportExpirationDate], [Airline]
+[DepartureCity], [PreferredAirline], [DestinationsInterestedIn]
+[PreferredDatesofTravel], [DestinationsNotInterestedIn], [VacationDetails]
+[ImportantAmenities], [RoomsNeeded]
+```
+
+Plus repeating blocks: `<passengerinfoi>...</passengerinfoi>`, `<frequentflyerti>...</frequentflyerti>`
+
+### Token Replacement — TravelerProfile Page (Form Fields)
+
+`Travelerprofileinformation.aspx.cs` does its OWN token replacement from form fields:
+
+```
+[TravelerFirstName], [TravelerMiddleName], [TravelerLastName], [CompanyName], [TravelerTitle]
+[DeptCostCenter], [EmailAddress], [BusinessPhone], [BusinessFax], [MobilePhone], [HomePhone]
+[BirthDate], [Gender], [PassportName], [PassportNumber], [PassportIssueDate], [PassportExpirationDate], [PlaceofIssue]
+[TravelerArrangerName], [TravelerArrangerPhone], [TravelerArrangerEmail]
+[EmergencyContactName], [EmergencyContactRelationship], [EmergencyContactPhone]
+[PreferredDepartureAirport], [PreferredCarrier], [OtherPreferredCarrier], [SeatingPreference], [SpecialMealRequirements]
+[SmokingPreference], [BedPreference], [SpecialRequirements]
+[OtherHotelMembership], [OtherHotelMembershipNumber], [VehicleSize]
+```
+
+Plus repeating blocks: `<frequentflyerti>...</frequentflyerti>`, `<hotelclubmembershipsti>...</hotelclubmembershipsti>`, `<rentalcarmembershipsti>...</rentalcarmembershipsti>`
+
+### Repeating Block Processing
+
+Legacy has custom block processors that:
+1. Find block markers in template (e.g., `<GuestBlockGI>...</GuestBlockGI>`)
+2. Extract the template between markers
+3. Loop through data collection (guests, passengers, frequent flyer entries, etc.)
+4. Replace tokens in each iteration
+5. Append all iterations, remove markers
+
+### SMTP Sending
+
+- Legacy: `PCentralEmailMessage` from `PCentralLib.email` — wraps SMTP
+- Modern: `ISmtpClient` / `SmtpClientWrapper` using `System.Net.Mail` — functionally equivalent, no DLL needed
+
+## Current Modern State
+
+| Component | Status | Gap |
+|-----------|--------|-----|
+| `IEmailService` interface | 5 methods defined | Missing: `SendVacationRequestEmailAsync` |
+| `EmailService.cs` | 221 lines, 5 methods | Only 9 tokens replaced; no guest blocks, no custom fields; templates from sidecar (returns empty) |
+| `Vacation.cshtml.cs` | Sends email with hardcoded HTML | Should use template file like legacy |
+| `TravelerProfile.cshtml.cs` | No email sending | Should send third-party email like legacy |
+| Template files | Not in modern project | Need to copy from `src/FlyITA/configuration/` |
+| `EmailController` (sidecar) | Returns empty stubs | Not needed — templates are files, not DB |
+| `SmtpClientWrapper` | Working | OK |
+| Email config (`appsettings.json`) | Template names empty | Need to set paths |
+
+## What Needs to Happen
+
+### 1. Copy template files to modern project
+
+Copy from `src/FlyITA/configuration/` to `src/FlyITA.Web/Templates/`:
+- `TravelerProfiler.html` — EXISTS in source
+- `VacationTravelRequest.html` — EXISTS in source
+
+**Not in source control** (program-specific, deployed per-environment on IIS):
+- `RegistrationConfirmationEmail.html`
+- `LogonCredentialsEmail.html`
+- `SeamlessLogonCredentialsEmail.html`
+- `ThirdPartyEmailTemplate.txt`
+
+These 4 templates are NOT available to copy. The `EmailService` standard email methods (registration, logon, forgot password) will continue to use the sidecar fallback (`GetEmailTemplateAsync`). Wiring those templates is deferred to deployment configuration.
+
+### 2. Add file-based template loading to EmailService
+
+- Load templates from `Templates/` folder first (file I/O)
+- If not found, fall back to sidecar (`GetEmailTemplateAsync`)
+- Use `IWebHostEnvironment.ContentRootPath` to resolve file paths
+
+### 3. Complete token replacement in EmailService
+
+Port all 40+ tokens from `CustomEmails.cs`. Group by data source:
+- **Participant data** — from sidecar `GetParticipantByIdAsync()`
+- **Program data** — from sidecar `GetProgramByIdAsync()`
+- **Contact numbers** — from sidecar `GetContactNumbersAsync()`
+- **Transportation data** — from sidecar `GetTransportationDetailsAsync()`
+- **Custom fields** — from sidecar `GetCustomFieldValuesAsync()`
+- **Guest data** — from sidecar `GetParticipantByIdAsync()` (includes party data if available) or new endpoint
+
+### 4. Add repeating block processor
+
+Port the `replaceGuestBlockGI`, `replaceGuestBlockTI` logic as a generic block processor:
+- Find block markers, extract template, loop through data, replace tokens per iteration
+
+### 5. Add vacation email method using templates
+
+- Add `SendVacationRequestEmailAsync()` to `IEmailService` / `EmailService`
+- Load `VacationTravelRequest.html` template
+- Accept form field values as parameters (not from PCentralLib — legacy does the same)
+- Process `<passengerinfoi>` and `<frequentflyerti>` repeating blocks
+- Replace all vacation-specific tokens from form data
+
+### 6. Wire Vacation page to use template-based email
+
+- Replace `BuildEmailBody()` hardcoded HTML with template-based approach
+- Call `IEmailService.SendVacationRequestEmailAsync()` passing form field values
+
+### 7. Add traveler profile email to TravelerProfile page
+
+- Add `SendTravelerProfileFormEmailAsync()` to `IEmailService` / `EmailService`
+- Load `TravelerProfiler.html` template
+- Accept form field values as parameters
+- Process repeating blocks for frequent flyer, hotel memberships, rental car
+- Replace all traveler-profile-specific tokens from form data
+
+### 8. Update EmailController stub (sidecar)
+
+The `EmailController` returns empty — it was designed to serve templates from DB. Since the 2 available templates are file-based, this controller is **not needed** for them. Keep the stub for program-specific templates (registration, logon, seamless logon) — those will be wired per-deployment. No changes needed now.
+
+### 9. Update config
+
+`EmailOptions` already has template path properties (`TravelerProfileTemplate`, `VacationTravelRequestTemplate`, etc.) — currently empty strings in `appsettings.json`. Set the file paths for the 2 templates that exist:
+- `TravelerProfileTemplate` → `Templates/TravelerProfiler.html`
+- `VacationTravelRequestTemplate` → `Templates/VacationTravelRequest.html`
+
+`VacationToEmail` and `VacationSubject` already exist in `EmailOptions`. Just need non-empty default values in config.
+
+## Acceptance Criteria
+
+1. Template files copied to `src/FlyITA.Web/Templates/`
+2. `EmailService` loads templates from files (with sidecar fallback)
+3. All 40+ token replacements ported from `CustomEmails.cs`
+4. Repeating block processor works for guest/passenger/frequent flyer blocks
+5. Vacation page sends template-based emails (not hardcoded HTML)
+6. TravelerProfile page sends third-party email on submit
+7. Existing `EmailService` tests updated; new tests for template loading and token replacement
+8. All existing tests pass; build succeeds with zero warnings
+
+## Out of Scope
+
+- Runtime testing of SMTP delivery (blocked on SMTP server access)
+- Program-specific templates (RegistrationConfirmation, LogonCredentials, SeamlessLogon, ThirdParty) — not in source, deployed per-environment
+- Standard email methods (SendRegistrationConfirmation, SendLogonCredentials, SendForgotPassword) — they exist in EmailService with basic token replacement. Improving their token replacement is in scope, but end-to-end testing requires program-specific templates (out of scope).
+- Guest block processing via sidecar — `GetParticipantByIdAsync()` returns flat dictionary, party guest data may not be included. Implement the block processor but defer runtime verification to #29.
+
+## Risks
+
+- **Guest/party data from sidecar** — `GetParticipantByIdAsync()` returns a flat dictionary; guest party members may not be included. Mitigation: implement the generic block processor, but guest blocks specifically may return empty until #29 verifies the sidecar data shape.
+- **Template file encoding** — Legacy uses `File.OpenText()` which defaults to UTF-8. Modern should match.

--- a/.speckit/tasks/issue-27.md
+++ b/.speckit/tasks/issue-27.md
@@ -1,0 +1,285 @@
+# Tasks: Email Templates — Port CustomEmails.cs Template Logic
+
+**Issue:** #27  
+**Plan:** `.speckit/plans/issue-27.md`  
+**Status:** CLEAN
+
+---
+
+## Task 1: Create IEmailTemplateLoader interface
+
+**File:** `src/FlyITA.Core/Interfaces/IEmailTemplateLoader.cs` (CREATE)
+
+**Given** EmailService needs to load templates from files or sidecar  
+**When** I create an abstraction for template loading  
+**Then** Core can depend on it without knowing about the file system
+
+**Changes:**
+```csharp
+public interface IEmailTemplateLoader
+{
+    Task<string?> LoadTemplateAsync(string templateName, CancellationToken ct = default);
+}
+```
+
+**Verification:** `dotnet build src/FlyITA.Core/`
+
+---
+
+## Task 2: Add NullEmailTemplateLoader to Core DI
+
+**File:** `src/FlyITA.Core/DependencyInjection.cs`
+
+**Given** Core follows the TryAdd/Null pattern for pluggable services  
+**When** I add NullEmailTemplateLoader  
+**Then** Core tests work without Web layer
+
+**Changes:**
+- Add `services.TryAddScoped<IEmailTemplateLoader, NullEmailTemplateLoader>()`
+- Add internal `NullEmailTemplateLoader` class that returns null
+
+**Verification:** `dotnet build src/FlyITA.Core/`
+
+---
+
+## Task 3: Create EmailTemplateEngine utility
+
+**File:** `src/FlyITA.Core/Services/EmailTemplateEngine.cs` (CREATE)
+
+**Given** CustomEmails.cs has 40+ token replacements and repeating block logic  
+**When** I port the token replacement as a pure utility class  
+**Then** all email methods can use it for consistent replacement
+
+**Methods:**
+- `static string ReplaceParticipantTokens(string body, Dictionary<string, object?> participant)` — `<<LegalFirstName>>`, `<<LegalLastName>>`, `<<LegalMiddleName>>`, `<<DateOfBirth>>`, `<<Gender>>`, `<<EmailAddress>>`, `[PARTICIPANT_NAME]`, `[PARTICIPANT_EMAIL]`, `[PARTICIPANT_USERNAME]`, `[PARTICIPANT_PASSWORD]`, `[FIRSTNAME]`, `[LASTNAME]`
+- `static string ReplaceProgramTokens(string body, Dictionary<string, object?> program)` — `[PROGRAM_NAME]`, `[PROGRAM_800NBR]`, `[PROGRAM_HQNAME]`, `[PROGRAM_URL]`, `[PROGRAM_EMAIL]`
+- `static string ReplaceContactTokens(string body, List<Dictionary<string, object?>> contacts)` — `<<BusinessPhone>>`, `<<BusinessFax>>`, `<<MobilePhone>>`, `<<HomePhone>>`
+- `static string ReplaceTransportationTokens(string body, Dictionary<string, object?> transportation)` — `<<TransportationType>>`, `<<TravelDates>>`, `<<PrefHomeDepartureTime>>`, `<<PrefDestDepartureTime>>`, `<<PrefAirline>>`, `<<PrefHomeDepartureCity>>`, `<<DriveTime>>`, `<<SeatPreference>>`, `<<AirRemarks>>`, `<<FrequentFlyerNumber>>`, `<<CheckInDate>>`, `<<CheckOutDate>>`, `<<Wheelchair>>`, `<<SpecialMeal>>`
+- `static string ReplaceCustomFieldTokens(string body, List<Dictionary<string, object?>> customFields)` — `<<CustomField.{name}>>` pattern
+- `static string ReplaceFormFieldTokens(string body, Dictionary<string, string> formValues)` — `[FieldName]` pattern for page-specific tokens
+- `static string ProcessRepeatingBlock(string body, string startTag, string endTag, List<Dictionary<string, string>> items)` — generic block processor
+
+**Verification:** `dotnet build src/FlyITA.Core/`
+
+---
+
+## Task 4: Unit tests for EmailTemplateEngine
+
+**File:** `tests/FlyITA.Core.Tests/Services/EmailTemplateEngineTests.cs` (CREATE)
+
+**Tests:**
+1. `ReplaceParticipantTokens_ReplacesAllKnownTokens`
+2. `ReplaceParticipantTokens_MissingKeys_ReplacesWithEmpty`
+3. `ReplaceProgramTokens_ReplacesAllKnownTokens`
+4. `ReplaceFormFieldTokens_ReplacesMatchingKeys`
+5. `ReplaceFormFieldTokens_UnmatchedTokens_LeftAlone`
+6. `ReplaceCustomFieldTokens_ReplacesMatchingFields`
+7. `ReplaceCustomFieldTokens_NoCustomFields_RemovesTokens`
+8. `ProcessRepeatingBlock_MultipleItems_ExpandsBlock`
+9. `ProcessRepeatingBlock_ZeroItems_RemovesBlock`
+10. `ProcessRepeatingBlock_NoMarkers_ReturnsSameBody`
+11. `ReplaceContactTokens_MapsToCorrectPhoneTypes`
+12. `ReplaceTransportationTokens_ReplacesAllTravelFields`
+
+**Verification:** `dotnet test tests/FlyITA.Core.Tests/`
+
+---
+
+## Task 5: Copy template files and configure paths
+
+**Files:**
+- COPY `src/FlyITA/configuration/TravelerProfiler.html` → `src/FlyITA.Web/Templates/TravelerProfiler.html`
+- COPY `src/FlyITA/configuration/VacationTravelRequest.html` → `src/FlyITA.Web/Templates/VacationTravelRequest.html`
+- MODIFY `src/FlyITA.Web/FlyITA.Web.csproj` — add `<Content>` items with `CopyToOutputDirectory`
+- MODIFY `src/FlyITA.Web/appsettings.json` — set template paths:
+  - `Email:TravelerProfileTemplate` → `TravelerProfiler.html`
+  - `Email:VacationTravelRequestTemplate` → `VacationTravelRequest.html`
+
+**Verification:** `dotnet build src/FlyITA.Web/` and template files appear in output
+
+---
+
+## Task 6: Create FileEmailTemplateLoader
+
+**File:** `src/FlyITA.Web/Services/FileEmailTemplateLoader.cs` (CREATE)
+
+**Given** templates are on disk first, sidecar fallback second  
+**When** I implement IEmailTemplateLoader  
+**Then** EmailService gets templates from the right source
+
+**Changes:**
+- Inject `IWebHostEnvironment`, `IPCentralDataAccess`, `IContextManager`, `ILogger<FileEmailTemplateLoader>`
+- `LoadTemplateAsync(templateName)`:
+  - Build path: `Path.Combine(env.ContentRootPath, "Templates", templateName)`
+  - If file exists: `await File.ReadAllTextAsync(path, ct)`
+  - Else: `await _dataAccess.GetEmailTemplateAsync(templateName, _context.ProgramID)`
+  - Log which source was used
+
+**Register in `Program.cs`:**
+```csharp
+builder.Services.AddScoped<IEmailTemplateLoader, FileEmailTemplateLoader>();
+```
+
+**Verification:** `dotnet build src/FlyITA.Web/`
+
+---
+
+## Task 7: Unit tests for FileEmailTemplateLoader
+
+**File:** `tests/FlyITA.Web.Tests/Services/FileEmailTemplateLoaderTests.cs` (CREATE)
+
+**Tests:**
+1. `LoadTemplate_FileExists_ReturnsFileContent` — mock env with temp dir, write file, verify content returned
+2. `LoadTemplate_FileMissing_FallsBackToSidecar` — no file, mock sidecar returns content
+3. `LoadTemplate_BothMissing_ReturnsNull` — no file, sidecar returns null
+
+**Verification:** `dotnet test tests/FlyITA.Web.Tests/`
+
+---
+
+## Task 8: Create VacationEmailData model
+
+**File:** `src/FlyITA.Core/Models/VacationEmailData.cs` (CREATE)
+
+**Properties:**
+- `ToEmail`, `FromEmail`, `Subject` (routing — page fills from EmailOptions)
+- `NameOfPersonRequesting`, `GeneralAndPassengerEmail`, `PhoneNumber`
+- `DepartureCity`, `PreferredAirline`, `DestinationsInterestedIn`, `PreferredDatesOfTravel`
+- `DestinationsNotInterestedIn`, `VacationDetails`, `ImportantAmenities`, `RoomsNeeded`
+- `List<PassengerData> Passengers` (FirstName, LastName, BirthDate, Gender, PassportNumber, PassportExpirationDate)
+- `List<FrequentFlyerData> FrequentFlyers` (Airline, Number)
+
+Inner classes `PassengerData` and `FrequentFlyerData`.
+
+**Verification:** `dotnet build src/FlyITA.Core/`
+
+---
+
+## Task 9: Create TravelerProfileEmailData model
+
+**File:** `src/FlyITA.Core/Models/TravelerProfileEmailData.cs` (CREATE)
+
+**Properties:**
+- `ToEmail`, `FromEmail`, `Subject` (routing)
+- All 30+ fields from legacy template tokens (most will be empty string from current form — populated as form is expanded)
+- `List<FrequentFlyerData> FrequentFlyers`
+- `List<HotelMembershipData> HotelMemberships` (HotelChain, MemberNumber)
+- `List<RentalCarMembershipData> RentalCarMemberships` (Company, MemberNumber)
+
+**Verification:** `dotnet build src/FlyITA.Core/`
+
+---
+
+## Task 10: Update IEmailService and EmailService
+
+**Files:**
+- `src/FlyITA.Core/Interfaces/IEmailService.cs` — add 2 methods
+- `src/FlyITA.Core/Services/EmailService.cs` — rewrite to use IEmailTemplateLoader + EmailTemplateEngine
+
+**Interface additions:**
+```csharp
+Task<ValidationResult> SendVacationRequestEmailAsync(VacationEmailData data);
+Task<ValidationResult> SendTravelerProfileFormEmailAsync(TravelerProfileEmailData data);
+```
+
+**EmailService changes:**
+- Add `IEmailTemplateLoader` to constructor
+- Replace all `_dataAccess.GetEmailTemplateAsync()` with `_templateLoader.LoadTemplateAsync()`
+- Replace `ReplacePlaceholdersAsync()` with `EmailTemplateEngine` methods for standard emails
+- Implement `SendVacationRequestEmailAsync`:
+  - Load template via `_templateLoader.LoadTemplateAsync(config["Email:VacationTravelRequestTemplate"])`
+  - Convert `VacationEmailData` form fields to `Dictionary<string, string>` for `ReplaceFormFieldTokens`
+  - Process `<passengerinfoi>` and `<frequentflyerti>` repeating blocks via `ProcessRepeatingBlock`
+  - Send via `_smtpClient`
+- Implement `SendTravelerProfileFormEmailAsync`:
+  - Same pattern with `TravelerProfiler.html` template
+  - Process `<frequentflyerti>`, `<hotelclubmembershipsti>`, `<rentalcarmembershipsti>` blocks
+
+**Verification:** `dotnet build src/FlyITA.Core/`
+
+---
+
+## Task 11: Update EmailService tests
+
+**File:** `tests/FlyITA.Core.Tests/Services/EmailServiceTests.cs`
+
+**Changes:**
+- Mock `IEmailTemplateLoader` instead of `IPCentralDataAccess.GetEmailTemplateAsync`
+- Add tests for `SendVacationRequestEmailAsync`:
+  - Template loaded → tokens replaced → email sent with correct body
+  - Template missing → returns error
+  - Repeating blocks populated correctly
+- Add tests for `SendTravelerProfileFormEmailAsync`:
+  - Same pattern
+- Verify existing standard email tests still pass
+
+**Verification:** `dotnet test tests/FlyITA.Core.Tests/`
+
+---
+
+## Task 12: Wire Vacation page to IEmailService
+
+**File:** `src/FlyITA.Web/Pages/Vacation.cshtml.cs`
+
+**Changes:**
+- Replace `ISmtpClient` constructor parameter with `IEmailService`
+- Remove private `SendVacationRequestEmailAsync` and `BuildEmailBody` methods
+- In `OnPostAsync`, after validation:
+  - Build `VacationEmailData` from form properties + `_emailOptions` (ToEmail, FromEmail, Subject)
+  - Call `await _emailService.SendVacationRequestEmailAsync(data)`
+  - Handle result (success/error)
+
+**Verification:** `dotnet build src/FlyITA.Web/`
+
+---
+
+## Task 13: Wire TravelerProfile page to send email
+
+**File:** `src/FlyITA.Web/Pages/TravelerProfile.cshtml.cs`
+
+**Changes:**
+- Add `IEmailService` and `IOptions<EmailOptions>` to constructor
+- In `OnPostAsync`, after successful save:
+  - Build `TravelerProfileEmailData` from form properties + email options
+  - Call `await _emailService.SendTravelerProfileFormEmailAsync(data)`
+  - Handle result (log error but don't fail the page — email is best-effort, matching legacy behavior)
+
+**Verification:** `dotnet build src/FlyITA.Web/`
+
+---
+
+## Task 14: Update page tests
+
+**Changes:**
+- Update Vacation page tests: verify `IEmailService.SendVacationRequestEmailAsync` is called (mock), not `ISmtpClient.SendAsync`
+- Add TravelerProfile test: verify `IEmailService.SendTravelerProfileFormEmailAsync` is called on POST
+- Verify `FormPageTests` still passes (GET requests unaffected by new constructor params)
+
+**Verification:** `dotnet test tests/FlyITA.Web.Tests/`
+
+---
+
+## Task 15: Full build + test verification
+
+**Steps:**
+1. `dotnet build FlyITA.Modern.sln` — zero warnings
+2. `dotnet test FlyITA.Modern.sln --filter "FullyQualifiedName!~E2E"` — all pass
+3. Grep for `BuildEmailBody` — should not exist in source (removed from Vacation page)
+4. Verify template files exist in build output
+
+---
+
+## Task Order & Dependencies
+
+```
+Task 1 (interface) → Task 2 (null impl) → Task 3 (engine) → Task 4 (engine tests)
+                                                              ↓
+Task 5 (templates) → Task 6 (loader) → Task 7 (loader tests)
+                                                              ↓
+Task 8 (vacation model) ──┐                                   
+Task 9 (profile model) ──┤→ Task 10 (EmailService) → Task 11 (service tests)
+                          │                                    ↓
+                          └── Task 12 (vacation page) → Task 13 (profile page)
+                                                              ↓
+                                                   Task 14 (page tests) → Task 15 (verify)
+```

--- a/src/FlyITA.Core/DependencyInjection.cs
+++ b/src/FlyITA.Core/DependencyInjection.cs
@@ -31,6 +31,7 @@ public static class DependencyInjection
         // Pluggable services — TryAdd so Web can override with real implementations
         services.TryAddSingleton<IEnvironmentService, NullEnvironmentService>();
         services.TryAddScoped<ISmtpClient, NullSmtpClient>();
+        services.TryAddScoped<IEmailTemplateLoader, NullEmailTemplateLoader>();
 
         // External service abstractions — TryAdd so Infrastructure can override
         services.TryAddScoped<ICaptchaService, NullCaptchaService>();
@@ -74,6 +75,12 @@ internal class NullEnvironmentService : IEnvironmentService
     public string Role => "CDT";
     public bool IsClientFacing => false;
     public string GetConnectionStringName() => "Default";
+}
+
+internal class NullEmailTemplateLoader : IEmailTemplateLoader
+{
+    public Task<string?> LoadTemplateAsync(string templateName, CancellationToken ct = default)
+        => Task.FromResult<string?>(null);
 }
 
 internal class NullSmtpClient : ISmtpClient

--- a/src/FlyITA.Core/Interfaces/IEmailService.cs
+++ b/src/FlyITA.Core/Interfaces/IEmailService.cs
@@ -9,4 +9,6 @@ public interface IEmailService
     Task<ValidationResult> SendForgotPasswordCredentialsAsync(int participantId, string? seamlessLoginUrl = null);
     Task<ValidationResult> SendTravelerProfileEmailAsync(int participantId);
     Task<string> PreviewLogonCredentialsAsync(int participantId);
+    Task<ValidationResult> SendVacationRequestEmailAsync(VacationEmailData data);
+    Task<ValidationResult> SendTravelerProfileFormEmailAsync(TravelerProfileEmailData data);
 }

--- a/src/FlyITA.Core/Interfaces/IEmailTemplateLoader.cs
+++ b/src/FlyITA.Core/Interfaces/IEmailTemplateLoader.cs
@@ -1,0 +1,6 @@
+namespace FlyITA.Core.Interfaces;
+
+public interface IEmailTemplateLoader
+{
+    Task<string?> LoadTemplateAsync(string templateName, CancellationToken ct = default);
+}

--- a/src/FlyITA.Core/Models/TravelerProfileEmailData.cs
+++ b/src/FlyITA.Core/Models/TravelerProfileEmailData.cs
@@ -1,0 +1,75 @@
+namespace FlyITA.Core.Models;
+
+public class TravelerProfileEmailData
+{
+    // Email routing (page fills from EmailOptions)
+    public string ToEmail { get; set; } = string.Empty;
+    public string FromEmail { get; set; } = string.Empty;
+    public string Subject { get; set; } = string.Empty;
+
+    // General Information
+    public string TravelerFirstName { get; set; } = string.Empty;
+    public string TravelerMiddleName { get; set; } = string.Empty;
+    public string TravelerLastName { get; set; } = string.Empty;
+    public string CompanyName { get; set; } = string.Empty;
+    public string TravelerTitle { get; set; } = string.Empty;
+    public string DeptCostCenter { get; set; } = string.Empty;
+    public string EmailAddress { get; set; } = string.Empty;
+    public string BusinessPhone { get; set; } = string.Empty;
+    public string BusinessFax { get; set; } = string.Empty;
+    public string MobilePhone { get; set; } = string.Empty;
+    public string HomePhone { get; set; } = string.Empty;
+    public string BirthDate { get; set; } = string.Empty;
+    public string Gender { get; set; } = string.Empty;
+
+    // Passport Information
+    public string PassportName { get; set; } = string.Empty;
+    public string PassportNumber { get; set; } = string.Empty;
+    public string PassportIssueDate { get; set; } = string.Empty;
+    public string PassportExpirationDate { get; set; } = string.Empty;
+    public string PlaceOfIssue { get; set; } = string.Empty;
+
+    // Traveler Arranger
+    public string TravelerArrangerName { get; set; } = string.Empty;
+    public string TravelerArrangerPhone { get; set; } = string.Empty;
+    public string TravelerArrangerEmail { get; set; } = string.Empty;
+
+    // Emergency Contact
+    public string EmergencyContactName { get; set; } = string.Empty;
+    public string EmergencyContactRelationship { get; set; } = string.Empty;
+    public string EmergencyContactPhone { get; set; } = string.Empty;
+
+    // Travel Preferences
+    public string PreferredDepartureAirport { get; set; } = string.Empty;
+    public string PreferredCarrier { get; set; } = string.Empty;
+    public string OtherPreferredCarrier { get; set; } = string.Empty;
+    public string SeatingPreference { get; set; } = string.Empty;
+    public string SpecialMealRequirements { get; set; } = string.Empty;
+
+    // Hotel Preferences
+    public string SmokingPreference { get; set; } = string.Empty;
+    public string BedPreference { get; set; } = string.Empty;
+    public string SpecialRequirements { get; set; } = string.Empty;
+    public string OtherHotelMembership { get; set; } = string.Empty;
+    public string OtherHotelMembershipNumber { get; set; } = string.Empty;
+
+    // Rental Car
+    public string VehicleSize { get; set; } = string.Empty;
+
+    // Repeating blocks
+    public List<FrequentFlyerData> FrequentFlyers { get; set; } = new();
+    public List<HotelMembershipData> HotelMemberships { get; set; } = new();
+    public List<RentalCarMembershipData> RentalCarMemberships { get; set; } = new();
+}
+
+public class HotelMembershipData
+{
+    public string HotelChain { get; set; } = string.Empty;
+    public string MemberNumber { get; set; } = string.Empty;
+}
+
+public class RentalCarMembershipData
+{
+    public string Company { get; set; } = string.Empty;
+    public string MemberNumber { get; set; } = string.Empty;
+}

--- a/src/FlyITA.Core/Models/VacationEmailData.cs
+++ b/src/FlyITA.Core/Models/VacationEmailData.cs
@@ -1,0 +1,43 @@
+namespace FlyITA.Core.Models;
+
+public class VacationEmailData
+{
+    // Email routing (page fills from EmailOptions)
+    public string ToEmail { get; set; } = string.Empty;
+    public string FromEmail { get; set; } = string.Empty;
+    public string Subject { get; set; } = string.Empty;
+
+    // Form fields matching legacy [Token] patterns
+    public string NameOfPersonRequesting { get; set; } = string.Empty;
+    public string GeneralAndPassengerEmail { get; set; } = string.Empty;
+    public string PhoneNumber { get; set; } = string.Empty;
+    public string DepartureCity { get; set; } = string.Empty;
+    public string PreferredAirline { get; set; } = string.Empty;
+    public string DestinationsInterestedIn { get; set; } = string.Empty;
+    public string PreferredDatesOfTravel { get; set; } = string.Empty;
+    public string DestinationsNotInterestedIn { get; set; } = string.Empty;
+    public string VacationDetails { get; set; } = string.Empty;
+    public string ImportantAmenities { get; set; } = string.Empty;
+    public string RoomsNeeded { get; set; } = string.Empty;
+
+    // Repeating blocks
+    public List<PassengerData> Passengers { get; set; } = new();
+    public List<FrequentFlyerData> FrequentFlyers { get; set; } = new();
+}
+
+public class PassengerData
+{
+    public string FirstName { get; set; } = string.Empty;
+    public string MiddleName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+    public string DateOfBirth { get; set; } = string.Empty;
+    public string Gender { get; set; } = string.Empty;
+    public string PassportNumber { get; set; } = string.Empty;
+    public string PassportExpiration { get; set; } = string.Empty;
+}
+
+public class FrequentFlyerData
+{
+    public string Airline { get; set; } = string.Empty;
+    public string Number { get; set; } = string.Empty;
+}

--- a/src/FlyITA.Core/Services/EmailService.cs
+++ b/src/FlyITA.Core/Services/EmailService.cs
@@ -12,42 +12,36 @@ public class EmailService : IEmailService
     private readonly IPCentralDataAccess _dataAccess;
     private readonly IConfiguration _configuration;
     private readonly ISmtpClient _smtpClient;
+    private readonly IEmailTemplateLoader _templateLoader;
 
-    public EmailService(IContextManager context, IPCentralDataAccess dataAccess, IConfiguration configuration, ISmtpClient smtpClient)
+    public EmailService(
+        IContextManager context,
+        IPCentralDataAccess dataAccess,
+        IConfiguration configuration,
+        ISmtpClient smtpClient,
+        IEmailTemplateLoader templateLoader)
     {
         _context = context;
         _dataAccess = dataAccess;
         _configuration = configuration;
         _smtpClient = smtpClient;
+        _templateLoader = templateLoader;
     }
 
     public async Task<ValidationResult> SendRegistrationConfirmationAsync(int participantId)
     {
         var result = new ValidationResult();
         var participant = await _dataAccess.GetParticipantByIdAsync(participantId);
-        if (participant == null)
-        {
-            result.AddError("Participant not found.");
-            return result;
-        }
+        if (participant == null) { result.AddError("Participant not found."); return result; }
 
-        var templateKey = _configuration["Email:RegistrationConfirmationTemplate"] ?? "RegistrationConfirmation";
-        var body = await _dataAccess.GetEmailTemplateAsync(templateKey, _context.ProgramID);
-        if (string.IsNullOrEmpty(body))
-        {
-            result.AddError("Email template not found.");
-            return result;
-        }
+        var templateName = _configuration["Email:RegistrationConfirmationTemplate"] ?? "RegistrationConfirmation";
+        var body = await _templateLoader.LoadTemplateAsync(templateName);
+        if (string.IsNullOrEmpty(body)) { result.AddError("Email template not found."); return result; }
 
-        body = await ReplacePlaceholdersAsync(body, participant);
+        body = await ReplaceStandardTokensAsync(body, participant);
         var subject = _configuration["Email:Subject"] ?? "Registration Confirmation";
         var to = GetParticipantEmail(participant);
-
-        if (string.IsNullOrEmpty(to))
-        {
-            result.AddError("Participant email address not found.");
-            return result;
-        }
+        if (string.IsNullOrEmpty(to)) { result.AddError("Participant email address not found."); return result; }
 
         await SendEmailAsync(to, subject, body, result);
         return result;
@@ -57,28 +51,15 @@ public class EmailService : IEmailService
     {
         var result = new ValidationResult();
         var participant = await _dataAccess.GetParticipantByIdAsync(participantId);
-        if (participant == null)
-        {
-            result.AddError("Participant not found.");
-            return result;
-        }
+        if (participant == null) { result.AddError("Participant not found."); return result; }
 
-        var templateKey = _configuration["Email:LogonCredentialsTemplate"] ?? "LogonCredentials";
-        var body = await _dataAccess.GetEmailTemplateAsync(templateKey, _context.ProgramID);
-        if (string.IsNullOrEmpty(body))
-        {
-            result.AddError("Email template not found.");
-            return result;
-        }
+        var templateName = _configuration["Email:LogonCredentialsTemplate"] ?? "LogonCredentials";
+        var body = await _templateLoader.LoadTemplateAsync(templateName);
+        if (string.IsNullOrEmpty(body)) { result.AddError("Email template not found."); return result; }
 
-        body = await ReplacePlaceholdersAsync(body, participant);
+        body = await ReplaceStandardTokensAsync(body, participant);
         var to = GetParticipantEmail(participant);
-
-        if (string.IsNullOrEmpty(to))
-        {
-            result.AddError("Participant email address not found.");
-            return result;
-        }
+        if (string.IsNullOrEmpty(to)) { result.AddError("Participant email address not found."); return result; }
 
         await SendEmailAsync(to, "Your Login Credentials", body, result);
         return result;
@@ -89,44 +70,32 @@ public class EmailService : IEmailService
         var participant = await _dataAccess.GetParticipantByIdAsync(participantId);
         if (participant == null) return "<p>Participant not found.</p>";
 
-        var templateKey = _configuration["Email:LogonCredentialsTemplate"] ?? "LogonCredentials";
-        var body = await _dataAccess.GetEmailTemplateAsync(templateKey, _context.ProgramID);
+        var templateName = _configuration["Email:LogonCredentialsTemplate"] ?? "LogonCredentials";
+        var body = await _templateLoader.LoadTemplateAsync(templateName);
         if (string.IsNullOrEmpty(body)) return "<p>Template not found.</p>";
 
-        return await ReplacePlaceholdersAsync(body, participant);
+        return await ReplaceStandardTokensAsync(body, participant);
     }
 
     public async Task<ValidationResult> SendForgotPasswordCredentialsAsync(int participantId, string? seamlessLoginUrl = null)
     {
         var result = new ValidationResult();
         var participant = await _dataAccess.GetParticipantByIdAsync(participantId);
-        if (participant == null)
-        {
-            result.AddError("Participant not found.");
-            return result;
-        }
+        if (participant == null) { result.AddError("Participant not found."); return result; }
 
-        var templateKey = seamlessLoginUrl != null
-            ? (_configuration["Email:SeamlessLogonTemplate"] ?? "SeamlessLogon")
+        var templateName = seamlessLoginUrl != null
+            ? (_configuration["Email:SeamlessLogonCredentialsTemplate"] ?? "SeamlessLogon")
             : (_configuration["Email:ForgotPasswordTemplate"] ?? "ForgotPassword");
 
-        var body = await _dataAccess.GetEmailTemplateAsync(templateKey, _context.ProgramID);
-        if (string.IsNullOrEmpty(body))
-        {
-            result.AddError("Email template not found.");
-            return result;
-        }
+        var body = await _templateLoader.LoadTemplateAsync(templateName);
+        if (string.IsNullOrEmpty(body)) { result.AddError("Email template not found."); return result; }
 
-        body = await ReplacePlaceholdersAsync(body, participant);
+        body = await ReplaceStandardTokensAsync(body, participant);
         if (seamlessLoginUrl != null)
             body = body.Replace("[SEAMLESS_LOGIN_URL]", seamlessLoginUrl);
 
         var to = GetParticipantEmail(participant);
-        if (string.IsNullOrEmpty(to))
-        {
-            result.AddError("Participant email address not found.");
-            return result;
-        }
+        if (string.IsNullOrEmpty(to)) { result.AddError("Participant email address not found."); return result; }
 
         await SendEmailAsync(to, "Password Reset", body, result);
         return result;
@@ -136,67 +105,174 @@ public class EmailService : IEmailService
     {
         var result = new ValidationResult();
         var participant = await _dataAccess.GetParticipantByIdAsync(participantId);
-        if (participant == null)
-        {
-            result.AddError("Participant not found.");
-            return result;
-        }
+        if (participant == null) { result.AddError("Participant not found."); return result; }
 
-        var templateKey = _configuration["Email:TravelerProfileTemplate"] ?? "TravelerProfile";
-        var body = await _dataAccess.GetEmailTemplateAsync(templateKey, _context.ProgramID);
-        if (string.IsNullOrEmpty(body))
-        {
-            result.AddError("Email template not found.");
-            return result;
-        }
+        var templateName = _configuration["Email:TravelerProfileTemplate"] ?? "TravelerProfile";
+        var body = await _templateLoader.LoadTemplateAsync(templateName);
+        if (string.IsNullOrEmpty(body)) { result.AddError("Email template not found."); return result; }
 
-        body = await ReplacePlaceholdersAsync(body, participant);
+        body = await ReplaceStandardTokensAsync(body, participant);
         var to = _configuration["Email:ToEmail"];
-
-        if (string.IsNullOrEmpty(to))
-        {
-            result.AddError("Email:ToEmail configuration is not set.");
-            return result;
-        }
+        if (string.IsNullOrEmpty(to)) { result.AddError("Email:ToEmail configuration is not set."); return result; }
 
         await SendEmailAsync(to, "Traveler Profile Submission", body, result);
         return result;
     }
 
-    public async Task<string> ReplacePlaceholdersAsync(string body, Dictionary<string, object?> participant)
+    public async Task<ValidationResult> SendVacationRequestEmailAsync(VacationEmailData data)
     {
-        body = ReplaceIfPresent(body, "<<LegalFirstName>>", participant, "LegalFirstName");
-        body = ReplaceIfPresent(body, "<<LegalLastName>>", participant, "LegalLastName");
-        body = ReplaceIfPresent(body, "<<LegalMiddleName>>", participant, "LegalMiddleName");
-        body = ReplaceIfPresent(body, "<<EmailAddress>>", participant, "EmailAddress");
-        body = ReplaceIfPresent(body, "<<Prefix>>", participant, "Prefix");
-        body = ReplaceIfPresent(body, "<<Suffix>>", participant, "Suffix");
-        body = ReplaceIfPresent(body, "<<TransportationType>>", participant, "TransportationType");
-        body = ReplaceIfPresent(body, "<<CheckInDate>>", participant, "CheckInDate");
-        body = ReplaceIfPresent(body, "<<CheckOutDate>>", participant, "CheckOutDate");
+        var result = new ValidationResult();
 
-        body = body.Replace("[PARTICIPANT_NAME]",
-            $"{GetValue(participant, "LegalFirstName")} {GetValue(participant, "LegalLastName")}");
+        var templateName = _configuration["Email:VacationTravelRequestTemplate"] ?? "VacationTravelRequest.html";
+        var body = await _templateLoader.LoadTemplateAsync(templateName);
+        if (string.IsNullOrEmpty(body)) { result.AddError("Vacation email template not found."); return result; }
 
-        var programData = await _dataAccess.GetProgramByIdAsync(_context.ProgramID);
-        if (programData != null)
+        // Replace form field tokens
+        var formFields = new Dictionary<string, string>
         {
-            body = ReplaceIfPresent(body, "[PROGRAM_URL]", programData, "ProgramURL");
-            body = ReplaceIfPresent(body, "[PROGRAM_EMAIL]", programData, "ProgramEmail");
-            body = ReplaceIfPresent(body, "[PROGRAM_PHONE]", programData, "ProgramPhone");
+            ["NameofPersonRequesting"] = data.NameOfPersonRequesting,
+            ["GeneralandPassengerEmail"] = data.GeneralAndPassengerEmail,
+            ["PhoneNumber"] = data.PhoneNumber,
+            ["DepartureCity"] = data.DepartureCity,
+            ["PreferredAirline"] = data.PreferredAirline,
+            ["DestinationsInterestedIn"] = data.DestinationsInterestedIn,
+            ["PreferredDatesofTravel"] = data.PreferredDatesOfTravel,
+            ["DestinationsNotInterestedIn"] = data.DestinationsNotInterestedIn,
+            ["VacationDetails"] = data.VacationDetails,
+            ["ImportantAmenities"] = data.ImportantAmenities,
+            ["RoomsNeeded"] = data.RoomsNeeded
+        };
+        body = EmailTemplateEngine.ReplaceFormFieldTokens(body, formFields);
+
+        // Process passenger repeating block
+        var passengers = data.Passengers.Select(p => new Dictionary<string, string>
+        {
+            ["<<pfirstname>>"] = p.FirstName,
+            ["<<pmiddlename>>"] = p.MiddleName,
+            ["<<plastname>>"] = p.LastName,
+            ["<<pdob>>"] = p.DateOfBirth,
+            ["<<pgender>>"] = p.Gender,
+            ["<<ppassportnumber>>"] = p.PassportNumber,
+            ["<<ppassportexp>>"] = p.PassportExpiration
+        }).ToList();
+        body = EmailTemplateEngine.ProcessRepeatingBlock(body, "<passengerinfoi>", "</passengerinfoi>", passengers);
+
+        // Process frequent flyer repeating block
+        var flyers = data.FrequentFlyers.Select(f => new Dictionary<string, string>
+        {
+            ["<<frequentflyernumber>>"] = f.Airline,
+            ["<<frequentflyernumberid>>"] = f.Number
+        }).ToList();
+        body = EmailTemplateEngine.ProcessRepeatingBlock(body, "<frequentflyerti>", "</frequentflyerti>", flyers);
+
+        var to = data.ToEmail;
+        var from = data.FromEmail;
+        var subject = data.Subject;
+
+        if (string.IsNullOrEmpty(to) || string.IsNullOrEmpty(from))
+        {
+            result.AddError("Vacation email routing not configured.");
+            return result;
         }
 
+        await SendEmailAsync(to, from, subject, body, result);
+        return result;
+    }
+
+    public async Task<ValidationResult> SendTravelerProfileFormEmailAsync(TravelerProfileEmailData data)
+    {
+        var result = new ValidationResult();
+
+        var templateName = _configuration["Email:TravelerProfileTemplate"] ?? "TravelerProfiler.html";
+        var body = await _templateLoader.LoadTemplateAsync(templateName);
+        if (string.IsNullOrEmpty(body)) { result.AddError("Traveler profile email template not found."); return result; }
+
+        // Replace form field tokens
+        var formFields = new Dictionary<string, string>
+        {
+            ["TravelerFirstName"] = data.TravelerFirstName,
+            ["TravelerMiddleName"] = data.TravelerMiddleName,
+            ["TravelerLastName"] = data.TravelerLastName,
+            ["CompanyName"] = data.CompanyName,
+            ["TravelerTitle"] = data.TravelerTitle,
+            ["DeptCostCenter"] = data.DeptCostCenter,
+            ["EmailAddress"] = data.EmailAddress,
+            ["BusinessPhone"] = data.BusinessPhone,
+            ["BusinessFax"] = data.BusinessFax,
+            ["MobilePhone"] = data.MobilePhone,
+            ["HomePhone"] = data.HomePhone,
+            ["BirthDate"] = data.BirthDate,
+            ["Gender"] = data.Gender,
+            ["PassportName"] = data.PassportName,
+            ["PassportNumber"] = data.PassportNumber,
+            ["PassportIssueDate"] = data.PassportIssueDate,
+            ["PassportExpirationDate"] = data.PassportExpirationDate,
+            ["PlaceofIssue"] = data.PlaceOfIssue,
+            ["TravelerArrangerName"] = data.TravelerArrangerName,
+            ["TravelerArrangerPhone"] = data.TravelerArrangerPhone,
+            ["TravelerArrangerEmail"] = data.TravelerArrangerEmail,
+            ["EmergencyContactName"] = data.EmergencyContactName,
+            ["EmergencyContactRelationship"] = data.EmergencyContactRelationship,
+            ["EmergencyContactPhone"] = data.EmergencyContactPhone,
+            ["PreferredDepartureAirport"] = data.PreferredDepartureAirport,
+            ["PreferredCarrier"] = data.PreferredCarrier,
+            ["OtherPreferredCarrier"] = data.OtherPreferredCarrier,
+            ["SeatingPreference"] = data.SeatingPreference,
+            ["SpecialMealRequirements"] = data.SpecialMealRequirements,
+            ["SmokingPreference"] = data.SmokingPreference,
+            ["BedPreference"] = data.BedPreference,
+            ["SpecialRequirements"] = data.SpecialRequirements,
+            ["OtherHotelMembership"] = data.OtherHotelMembership,
+            ["OtherHotelMembershipNumber"] = data.OtherHotelMembershipNumber,
+            ["VehicleSize"] = data.VehicleSize
+        };
+        body = EmailTemplateEngine.ReplaceFormFieldTokens(body, formFields);
+
+        // Process repeating blocks
+        var flyers = data.FrequentFlyers.Select(f => new Dictionary<string, string>
+        {
+            ["<<frequentflyernumber>>"] = f.Airline,
+            ["<<frequentflyernumberid>>"] = f.Number
+        }).ToList();
+        body = EmailTemplateEngine.ProcessRepeatingBlock(body, "<frequentflyerti>", "</frequentflyerti>", flyers);
+
+        var hotels = data.HotelMemberships.Select(h => new Dictionary<string, string>
+        {
+            ["<<hotelclubmemberships>>"] = h.HotelChain,
+            ["<<hotelclubmembershipsid>>"] = h.MemberNumber
+        }).ToList();
+        body = EmailTemplateEngine.ProcessRepeatingBlock(body, "<hotelclubmembershipsti>", "</hotelclubmembershipsti>", hotels);
+
+        var cars = data.RentalCarMemberships.Select(c => new Dictionary<string, string>
+        {
+            ["<<rentalcarmemberships>>"] = c.Company,
+            ["<<rentalcarmembershipsid>>"] = c.MemberNumber
+        }).ToList();
+        body = EmailTemplateEngine.ProcessRepeatingBlock(body, "<rentalcarmembershipsti>", "</rentalcarmembershipsti>", cars);
+
+        var to = data.ToEmail;
+        var from = data.FromEmail;
+        var subject = data.Subject;
+
+        if (string.IsNullOrEmpty(to) || string.IsNullOrEmpty(from))
+        {
+            result.AddError("Traveler profile email routing not configured.");
+            return result;
+        }
+
+        await SendEmailAsync(to, from, subject, body, result);
+        return result;
+    }
+
+    private async Task<string> ReplaceStandardTokensAsync(string body, Dictionary<string, object?> participant)
+    {
+        body = EmailTemplateEngine.ReplaceParticipantTokens(body, participant);
+
+        var program = await _dataAccess.GetProgramByIdAsync(_context.ProgramID);
+        if (program != null)
+            body = EmailTemplateEngine.ReplaceProgramTokens(body, program);
+
         return body;
-    }
-
-    private static string ReplaceIfPresent(string body, string placeholder, Dictionary<string, object?> data, string key)
-    {
-        return body.Replace(placeholder, GetValue(data, key));
-    }
-
-    private static string GetValue(Dictionary<string, object?> data, string key)
-    {
-        return data.TryGetValue(key, out var val) ? val?.ToString() ?? "" : "";
     }
 
     private static string? GetParticipantEmail(Dictionary<string, object?> participant)
@@ -206,9 +282,14 @@ public class EmailService : IEmailService
 
     private async Task SendEmailAsync(string to, string subject, string body, ValidationResult result)
     {
+        var from = _configuration["Email:SmtpFrom"] ?? "noreply@itagroup.com";
+        await SendEmailAsync(to, from, subject, body, result);
+    }
+
+    private async Task SendEmailAsync(string to, string from, string subject, string body, ValidationResult result)
+    {
         try
         {
-            var from = _configuration["Email:SmtpFrom"] ?? "noreply@itagroup.com";
             using var message = new MailMessage(from, to, subject, body) { IsBodyHtml = true };
             await _smtpClient.SendAsync(message);
         }

--- a/src/FlyITA.Core/Services/EmailTemplateEngine.cs
+++ b/src/FlyITA.Core/Services/EmailTemplateEngine.cs
@@ -1,0 +1,152 @@
+using System.Text;
+
+namespace FlyITA.Core.Services;
+
+public static class EmailTemplateEngine
+{
+    public static string ReplaceParticipantTokens(string body, Dictionary<string, object?> participant)
+    {
+        body = ReplaceToken(body, "<<LegalFirstName>>", participant, "LegalFirstName");
+        body = ReplaceToken(body, "<<LegalMiddleName>>", participant, "LegalMiddleName");
+        body = ReplaceToken(body, "<<LegalLastName>>", participant, "LegalLastName");
+        body = ReplaceToken(body, "<<DateOfBirth>>", participant, "DateOfBirth");
+        body = ReplaceToken(body, "<<Gender>>", participant, "Gender");
+        body = ReplaceToken(body, "<<EmailAddress>>", participant, "EmailAddress");
+        body = ReplaceToken(body, "<<Prefix>>", participant, "Prefix");
+        body = ReplaceToken(body, "<<Suffix>>", participant, "Suffix");
+
+        body = body.Replace("[PARTICIPANT_NAME]",
+            $"{GetValue(participant, "LegalFirstName")} {GetValue(participant, "LegalLastName")}".Trim());
+        body = ReplaceToken(body, "[PARTICIPANT_EMAIL]", participant, "EmailAddress");
+        body = ReplaceToken(body, "[PARTICIPANT_USERNAME]", participant, "UserName");
+        body = ReplaceToken(body, "[PARTICIPANT_PASSWORD]", participant, "Password");
+        body = ReplaceToken(body, "[FIRSTNAME]", participant, "LegalFirstName");
+        body = ReplaceToken(body, "[LASTNAME]", participant, "LegalLastName");
+
+        return body;
+    }
+
+    public static string ReplaceProgramTokens(string body, Dictionary<string, object?> program)
+    {
+        body = ReplaceToken(body, "[PROGRAM_NAME]", program, "ProgramName");
+        body = ReplaceToken(body, "[PROGRAM_800NBR]", program, "ProgramTollFreeNbr");
+        body = ReplaceToken(body, "[PROGRAM_HQNAME]", program, "TravelHeadquartersName");
+        body = ReplaceToken(body, "[PROGRAM_URL]", program, "WebRegistrationSiteUrl");
+        body = ReplaceToken(body, "[PROGRAM_EMAIL]", program, "FromEmailAddress");
+
+        return body;
+    }
+
+    public static string ReplaceContactTokens(string body, List<Dictionary<string, object?>> contacts)
+    {
+        string business = "", fax = "", mobile = "", home = "";
+
+        foreach (var contact in contacts)
+        {
+            var type = GetValue(contact, "ContactType").ToLowerInvariant();
+            var number = GetValue(contact, "ContactNumber");
+
+            switch (type)
+            {
+                case "business": business = number; break;
+                case "fax": fax = number; break;
+                case "mobile": mobile = number; break;
+                case "home": home = number; break;
+            }
+        }
+
+        body = body.Replace("<<BusinessPhone>>", business);
+        body = body.Replace("<<BusinessFax>>", fax);
+        body = body.Replace("<<MobilePhone>>", mobile);
+        body = body.Replace("<<HomePhone>>", home);
+
+        return body;
+    }
+
+    public static string ReplaceTransportationTokens(string body, Dictionary<string, object?> transportation)
+    {
+        body = ReplaceToken(body, "<<TransportationType>>", transportation, "TransportationType");
+        body = ReplaceToken(body, "<<TravelDates>>", transportation, "TravelDates");
+        body = ReplaceToken(body, "<<PrefHomeDepartureTime>>", transportation, "PrefHomeDepartureTime");
+        body = ReplaceToken(body, "<<PrefDestDepartureTime>>", transportation, "PrefDestDepartureTime");
+        body = ReplaceToken(body, "<<PrefAirline>>", transportation, "PrefAirline");
+        body = ReplaceToken(body, "<<PrefHomeDepartureCity>>", transportation, "PrefHomeDepartureCity");
+        body = ReplaceToken(body, "<<DriveTime>>", transportation, "DriveTime");
+        body = ReplaceToken(body, "<<SeatPreference>>", transportation, "SeatPreference");
+        body = ReplaceToken(body, "<<AirRemarks>>", transportation, "AirRemarks");
+        body = ReplaceToken(body, "<<FrequentFlyerNumber>>", transportation, "FrequentFlyerNumber");
+        body = ReplaceToken(body, "<<CheckInDate>>", transportation, "CheckInDate");
+        body = ReplaceToken(body, "<<CheckOutDate>>", transportation, "CheckOutDate");
+        body = ReplaceToken(body, "<<Wheelchair>>", transportation, "Wheelchair");
+        body = ReplaceToken(body, "<<SpecialMeal>>", transportation, "SpecialMeal");
+
+        return body;
+    }
+
+    public static string ReplaceCustomFieldTokens(string body, List<Dictionary<string, object?>> customFields)
+    {
+        if (!body.Contains("<<CustomField."))
+            return body;
+
+        foreach (var cf in customFields)
+        {
+            var name = GetValue(cf, "Name");
+            var value = GetValue(cf, "Value");
+            if (!string.IsNullOrEmpty(name))
+                body = body.Replace($"<<CustomField.{name}>>", value);
+        }
+
+        return body;
+    }
+
+    public static string ReplaceFormFieldTokens(string body, Dictionary<string, string> formValues)
+    {
+        foreach (var (key, value) in formValues)
+        {
+            body = body.Replace($"[{key}]", value ?? "");
+        }
+        return body;
+    }
+
+    public static string ProcessRepeatingBlock(string body, string startTag, string endTag, List<Dictionary<string, string>> items)
+    {
+        int startsAt = body.IndexOf(startTag, StringComparison.OrdinalIgnoreCase);
+        int endsAt = body.IndexOf(endTag, StringComparison.OrdinalIgnoreCase);
+
+        if (startsAt < 0 || endsAt < 0 || endsAt <= startsAt)
+            return body;
+
+        string template = body.Substring(startsAt + startTag.Length, endsAt - startsAt - startTag.Length);
+
+        // Trim trailing newlines from template (matching legacy behavior)
+        while (template.EndsWith("\r\n"))
+            template = template[..^2];
+
+        var expanded = new StringBuilder();
+        foreach (var item in items)
+        {
+            string block = template;
+            foreach (var (token, value) in item)
+            {
+                block = block.Replace(token, value ?? "");
+            }
+            expanded.Append(block);
+        }
+
+        // Replace the entire block (markers + template) with expanded content
+        string fullBlock = body[startsAt..(endsAt + endTag.Length)];
+        body = body.Replace(fullBlock, expanded.ToString());
+
+        return body;
+    }
+
+    private static string ReplaceToken(string body, string placeholder, Dictionary<string, object?> data, string key)
+    {
+        return body.Replace(placeholder, GetValue(data, key));
+    }
+
+    private static string GetValue(Dictionary<string, object?> data, string key)
+    {
+        return data.TryGetValue(key, out var val) ? val?.ToString() ?? "" : "";
+    }
+}

--- a/src/FlyITA.Core/Services/EmailTemplateEngine.cs
+++ b/src/FlyITA.Core/Services/EmailTemplateEngine.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text;
 
 namespace FlyITA.Core.Services;
@@ -103,7 +104,7 @@ public static class EmailTemplateEngine
     {
         foreach (var (key, value) in formValues)
         {
-            body = body.Replace($"[{key}]", value ?? "");
+            body = body.Replace($"[{key}]", WebUtility.HtmlEncode(value ?? ""));
         }
         return body;
     }
@@ -111,9 +112,10 @@ public static class EmailTemplateEngine
     public static string ProcessRepeatingBlock(string body, string startTag, string endTag, List<Dictionary<string, string>> items)
     {
         int startsAt = body.IndexOf(startTag, StringComparison.OrdinalIgnoreCase);
-        int endsAt = body.IndexOf(endTag, StringComparison.OrdinalIgnoreCase);
+        if (startsAt < 0) return body;
+        int endsAt = body.IndexOf(endTag, startsAt + startTag.Length, StringComparison.OrdinalIgnoreCase);
 
-        if (startsAt < 0 || endsAt < 0 || endsAt <= startsAt)
+        if (endsAt < 0)
             return body;
 
         string template = body.Substring(startsAt + startTag.Length, endsAt - startsAt - startTag.Length);
@@ -128,7 +130,7 @@ public static class EmailTemplateEngine
             string block = template;
             foreach (var (token, value) in item)
             {
-                block = block.Replace(token, value ?? "");
+                block = block.Replace(token, WebUtility.HtmlEncode(value ?? ""));
             }
             expanded.Append(block);
         }

--- a/src/FlyITA.Web/FlyITA.Web.csproj
+++ b/src/FlyITA.Web/FlyITA.Web.csproj
@@ -12,6 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="Templates\**" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.*" />
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.*" />
   </ItemGroup>

--- a/src/FlyITA.Web/Pages/TravelerProfile.cshtml.cs
+++ b/src/FlyITA.Web/Pages/TravelerProfile.cshtml.cs
@@ -112,7 +112,14 @@ public class TravelerProfileModel : PageModel
                 : new List<RentalCarMembershipData>()
         };
 
-        await _emailService.SendTravelerProfileFormEmailAsync(emailData);
+        try
+        {
+            await _emailService.SendTravelerProfileFormEmailAsync(emailData);
+        }
+        catch
+        {
+            // Best-effort — email failure should not prevent profile save
+        }
 
         SuccessMessage = "Traveler profile saved successfully.";
         if (personId.HasValue) await LoadPersonDataAsync(personId.Value);

--- a/src/FlyITA.Web/Pages/TravelerProfile.cshtml.cs
+++ b/src/FlyITA.Web/Pages/TravelerProfile.cshtml.cs
@@ -1,8 +1,11 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Options;
 using FlyITA.Core.Abstractions;
 using FlyITA.Core.Interfaces;
+using FlyITA.Core.Models;
+using FlyITA.Web.Options;
 
 namespace FlyITA.Web.Pages;
 
@@ -10,11 +13,19 @@ public class TravelerProfileModel : PageModel
 {
     private readonly IPCentralDataAccess _dataAccess;
     private readonly ICaptchaService _captchaService;
+    private readonly IEmailService _emailService;
+    private readonly EmailOptions _emailOptions;
 
-    public TravelerProfileModel(IPCentralDataAccess dataAccess, ICaptchaService captchaService)
+    public TravelerProfileModel(
+        IPCentralDataAccess dataAccess,
+        ICaptchaService captchaService,
+        IEmailService emailService,
+        IOptions<EmailOptions> emailOptions)
     {
         _dataAccess = dataAccess;
         _captchaService = captchaService;
+        _emailService = emailService;
+        _emailOptions = emailOptions.Value;
     }
 
     // Person data loaded on GET
@@ -72,6 +83,36 @@ public class TravelerProfileModel : PageModel
                 return Page();
             }
         }
+
+        // Send traveler profile email (best-effort — don't fail the page if email fails)
+        var emailData = new TravelerProfileEmailData
+        {
+            ToEmail = _emailOptions.ThirdPartyToEmail,
+            FromEmail = !string.IsNullOrEmpty(_emailOptions.ThirdPartyFromEmail)
+                ? _emailOptions.ThirdPartyFromEmail
+                : _emailOptions.SmtpFrom,
+            Subject = !string.IsNullOrEmpty(_emailOptions.ThirdPartySubject)
+                ? _emailOptions.ThirdPartySubject
+                : "Traveler Profile Submission",
+            TravelerFirstName = FirstName,
+            TravelerLastName = LastName,
+            EmailAddress = Email,
+            BusinessPhone = Phone,
+            CompanyName = Company,
+            FrequentFlyers = FrequentFlyers
+                .Where(f => !string.IsNullOrWhiteSpace(f.Airline))
+                .Select(f => new FrequentFlyerData { Airline = f.Airline, Number = f.MemberNumber })
+                .ToList(),
+            HotelMemberships = HotelMemberships
+                .Where(h => !string.IsNullOrWhiteSpace(h.HotelChain))
+                .Select(h => new HotelMembershipData { HotelChain = h.HotelChain, MemberNumber = h.MemberNumber })
+                .ToList(),
+            RentalCarMemberships = !string.IsNullOrWhiteSpace(RentalCarCompany)
+                ? new List<RentalCarMembershipData> { new() { Company = RentalCarCompany, MemberNumber = RentalCarMemberNumber } }
+                : new List<RentalCarMembershipData>()
+        };
+
+        await _emailService.SendTravelerProfileFormEmailAsync(emailData);
 
         SuccessMessage = "Traveler profile saved successfully.";
         if (personId.HasValue) await LoadPersonDataAsync(personId.Value);

--- a/src/FlyITA.Web/Pages/Vacation.cshtml.cs
+++ b/src/FlyITA.Web/Pages/Vacation.cshtml.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Options;
 using FlyITA.Core.Interfaces;
+using FlyITA.Core.Models;
 using FlyITA.Web.Options;
 
 namespace FlyITA.Web.Pages;
@@ -10,13 +11,13 @@ namespace FlyITA.Web.Pages;
 public class VacationModel : PageModel
 {
     private readonly ICaptchaService _captchaService;
-    private readonly ISmtpClient _smtpClient;
+    private readonly IEmailService _emailService;
     private readonly EmailOptions _emailOptions;
 
-    public VacationModel(ICaptchaService captchaService, ISmtpClient smtpClient, IOptions<EmailOptions> emailOptions)
+    public VacationModel(ICaptchaService captchaService, IEmailService emailService, IOptions<EmailOptions> emailOptions)
     {
         _captchaService = captchaService;
-        _smtpClient = smtpClient;
+        _emailService = emailService;
         _emailOptions = emailOptions.Value;
     }
 
@@ -132,10 +133,47 @@ public class VacationModel : PageModel
             }
         }
 
-        // Build and send email
+        // Build and send email via template
         try
         {
-            await SendVacationRequestEmailAsync(validPassengers);
+            var data = new VacationEmailData
+            {
+                ToEmail = _emailOptions.VacationToEmail,
+                FromEmail = _emailOptions.SmtpFrom,
+                Subject = !string.IsNullOrWhiteSpace(_emailOptions.VacationSubject) ? _emailOptions.VacationSubject : "Vacation Travel Request",
+                NameOfPersonRequesting = NameOfPersonRequesting,
+                GeneralAndPassengerEmail = GeneralAndPassengerEmail,
+                PhoneNumber = PhoneNumber,
+                DepartureCity = DepartureCity,
+                PreferredAirline = PreferredAirline,
+                DestinationsInterestedIn = DestinationsInterestedIn,
+                PreferredDatesOfTravel = PreferredDatesOfTravel,
+                DestinationsNotInterestedIn = DestinationsNotInterestedIn,
+                VacationDetails = VacationDetails,
+                ImportantAmenities = ImportantAmenities,
+                RoomsNeeded = RoomsNeeded,
+                Passengers = validPassengers.Select(p => new PassengerData
+                {
+                    FirstName = p.FirstName,
+                    MiddleName = p.MiddleName,
+                    LastName = p.LastName,
+                    DateOfBirth = p.DateOfBirth,
+                    Gender = p.Gender,
+                    PassportNumber = p.PassportNumber,
+                    PassportExpiration = p.PassportExpiration
+                }).ToList(),
+                FrequentFlyers = FrequentFlyers
+                    .Where(f => !string.IsNullOrWhiteSpace(f.Airline))
+                    .Select(f => new FrequentFlyerData { Airline = f.Airline, Number = f.Number })
+                    .ToList()
+            };
+
+            var emailResult = await _emailService.SendVacationRequestEmailAsync(data);
+            if (!emailResult.IsValid)
+            {
+                ModelState.AddModelError("", "We were unable to submit your request right now. Please try again later.");
+                return Page();
+            }
         }
         catch (Exception)
         {
@@ -144,68 +182,6 @@ public class VacationModel : PageModel
         }
 
         return RedirectToPage("/ThankYou", new { page = "Vacation" });
-    }
-
-    private async Task SendVacationRequestEmailAsync(List<PassengerEntry> passengers)
-    {
-        var body = BuildEmailBody(passengers);
-        var to = _emailOptions.VacationToEmail;
-        var from = _emailOptions.SmtpFrom;
-        var subject = _emailOptions.VacationSubject;
-
-        if (!string.IsNullOrEmpty(to) && !string.IsNullOrEmpty(from))
-        {
-            using var message = new System.Net.Mail.MailMessage(from, to, !string.IsNullOrWhiteSpace(subject) ? subject : "Vacation Travel Request", body)
-            {
-                IsBodyHtml = true
-            };
-            await _smtpClient.SendAsync(message);
-        }
-    }
-
-    private string BuildEmailBody(List<PassengerEntry> passengers)
-    {
-        var sb = new System.Text.StringBuilder();
-        sb.AppendLine("<html><body>");
-        sb.AppendLine("<h2>Vacation Travel Request</h2>");
-        sb.AppendLine($"<p><strong>Requested by:</strong> {System.Net.WebUtility.HtmlEncode(NameOfPersonRequesting)}</p>");
-        sb.AppendLine($"<p><strong>Email:</strong> {System.Net.WebUtility.HtmlEncode(GeneralAndPassengerEmail)}</p>");
-        sb.AppendLine($"<p><strong>Phone:</strong> {System.Net.WebUtility.HtmlEncode(PhoneNumber)}</p>");
-
-        sb.AppendLine("<h3>Passengers</h3>");
-        for (int i = 0; i < passengers.Count; i++)
-        {
-            var p = passengers[i];
-            sb.AppendLine($"<p><strong>Passenger {i + 1}:</strong> {System.Net.WebUtility.HtmlEncode(p.FirstName)} {System.Net.WebUtility.HtmlEncode(p.MiddleName)} {System.Net.WebUtility.HtmlEncode(p.LastName)}<br>");
-            sb.AppendLine($"DOB: {System.Net.WebUtility.HtmlEncode(p.DateOfBirth)} | Gender: {System.Net.WebUtility.HtmlEncode(p.Gender)}<br>");
-            if (!string.IsNullOrWhiteSpace(p.PassportNumber))
-                sb.AppendLine($"Passport: {System.Net.WebUtility.HtmlEncode(p.PassportNumber)} (Exp: {System.Net.WebUtility.HtmlEncode(p.PassportExpiration)})<br>");
-            sb.AppendLine("</p>");
-        }
-
-        var activeFlyers = FrequentFlyers.Where(f => !string.IsNullOrWhiteSpace(f.Airline)).ToList();
-        if (activeFlyers.Count > 0)
-        {
-            sb.AppendLine("<h3>Frequent Flyer Programs</h3>");
-            foreach (var ff in activeFlyers)
-                sb.AppendLine($"<p>{System.Net.WebUtility.HtmlEncode(ff.Airline)}: {System.Net.WebUtility.HtmlEncode(ff.Number)}</p>");
-        }
-
-        sb.AppendLine("<h3>Trip Information</h3>");
-        sb.AppendLine($"<p><strong>Departure City:</strong> {System.Net.WebUtility.HtmlEncode(DepartureCity)}</p>");
-        sb.AppendLine($"<p><strong>Preferred Airline:</strong> {System.Net.WebUtility.HtmlEncode(PreferredAirline)}</p>");
-        sb.AppendLine($"<p><strong>Destinations:</strong> {System.Net.WebUtility.HtmlEncode(DestinationsInterestedIn)}</p>");
-        sb.AppendLine($"<p><strong>Preferred Dates:</strong> {System.Net.WebUtility.HtmlEncode(PreferredDatesOfTravel)}</p>");
-        if (!string.IsNullOrWhiteSpace(DestinationsNotInterestedIn))
-            sb.AppendLine($"<p><strong>Not Interested In:</strong> {System.Net.WebUtility.HtmlEncode(DestinationsNotInterestedIn)}</p>");
-        if (!string.IsNullOrWhiteSpace(VacationDetails))
-            sb.AppendLine($"<p><strong>Details:</strong> {System.Net.WebUtility.HtmlEncode(VacationDetails)}</p>");
-        if (!string.IsNullOrWhiteSpace(ImportantAmenities))
-            sb.AppendLine($"<p><strong>Amenities:</strong> {System.Net.WebUtility.HtmlEncode(ImportantAmenities)}</p>");
-        sb.AppendLine($"<p><strong>Rooms Needed:</strong> {System.Net.WebUtility.HtmlEncode(RoomsNeeded)}</p>");
-
-        sb.AppendLine("</body></html>");
-        return sb.ToString();
     }
 
     public class PassengerEntry

--- a/src/FlyITA.Web/Program.cs
+++ b/src/FlyITA.Web/Program.cs
@@ -51,6 +51,7 @@ builder.Services.AddFlyITAInfrastructure();
 // 3. Web services (override Core's null defaults for environment and SMTP)
 builder.Services.AddSingleton<IEnvironmentService, EnvironmentService>();
 builder.Services.AddScoped<ISmtpClient, SmtpClientWrapper>();
+builder.Services.AddScoped<IEmailTemplateLoader, FileEmailTemplateLoader>();
 
 // Session (uses AppSessionOptions for timeout)
 var appSessionOptions = builder.Configuration

--- a/src/FlyITA.Web/Services/FileEmailTemplateLoader.cs
+++ b/src/FlyITA.Web/Services/FileEmailTemplateLoader.cs
@@ -1,0 +1,40 @@
+using FlyITA.Core.Abstractions;
+using FlyITA.Core.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace FlyITA.Web.Services;
+
+public class FileEmailTemplateLoader : IEmailTemplateLoader
+{
+    private readonly IWebHostEnvironment _env;
+    private readonly IPCentralDataAccess _dataAccess;
+    private readonly IContextManager _context;
+    private readonly ILogger<FileEmailTemplateLoader> _logger;
+
+    public FileEmailTemplateLoader(
+        IWebHostEnvironment env,
+        IPCentralDataAccess dataAccess,
+        IContextManager context,
+        ILogger<FileEmailTemplateLoader> logger)
+    {
+        _env = env;
+        _dataAccess = dataAccess;
+        _context = context;
+        _logger = logger;
+    }
+
+    public async Task<string?> LoadTemplateAsync(string templateName, CancellationToken ct = default)
+    {
+        // Try local file first
+        var path = Path.Combine(_env.ContentRootPath, "Templates", templateName);
+        if (File.Exists(path))
+        {
+            _logger.LogDebug("Loading email template from file: {Path}", path);
+            return await File.ReadAllTextAsync(path, ct);
+        }
+
+        // Fall back to sidecar (for program-specific templates deployed per-environment)
+        _logger.LogDebug("Template file not found at {Path}, falling back to sidecar for {TemplateName}", path, templateName);
+        return await _dataAccess.GetEmailTemplateAsync(templateName, _context.ProgramID);
+    }
+}

--- a/src/FlyITA.Web/Services/FileEmailTemplateLoader.cs
+++ b/src/FlyITA.Web/Services/FileEmailTemplateLoader.cs
@@ -25,16 +25,41 @@ public class FileEmailTemplateLoader : IEmailTemplateLoader
 
     public async Task<string?> LoadTemplateAsync(string templateName, CancellationToken ct = default)
     {
-        // Try local file first
-        var path = Path.Combine(_env.ContentRootPath, "Templates", templateName);
-        if (File.Exists(path))
+        // Reject path traversal attempts
+        if (string.IsNullOrWhiteSpace(templateName) ||
+            templateName.Contains("..") ||
+            Path.IsPathRooted(templateName))
         {
-            _logger.LogDebug("Loading email template from file: {Path}", path);
-            return await File.ReadAllTextAsync(path, ct);
+            _logger.LogWarning("Rejected invalid template name: {TemplateName}", templateName);
+            return null;
+        }
+
+        // Try local file first
+        try
+        {
+            var templatesDir = Path.Combine(_env.ContentRootPath, "Templates");
+            var path = Path.GetFullPath(Path.Combine(templatesDir, templateName));
+
+            // Ensure resolved path is still under Templates directory
+            if (!path.StartsWith(Path.GetFullPath(templatesDir), StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogWarning("Template path escaped Templates directory: {Path}", path);
+                return null;
+            }
+
+            if (File.Exists(path))
+            {
+                _logger.LogDebug("Loading email template from file: {Path}", path);
+                return await File.ReadAllTextAsync(path, ct);
+            }
+        }
+        catch (IOException ex)
+        {
+            _logger.LogWarning(ex, "Failed to read template file {TemplateName}, falling back to sidecar", templateName);
         }
 
         // Fall back to sidecar (for program-specific templates deployed per-environment)
-        _logger.LogDebug("Template file not found at {Path}, falling back to sidecar for {TemplateName}", path, templateName);
+        _logger.LogDebug("Template file not found locally, falling back to sidecar for {TemplateName}", templateName);
         return await _dataAccess.GetEmailTemplateAsync(templateName, _context.ProgramID);
     }
 }

--- a/src/FlyITA.Web/Templates/TravelerProfiler.html
+++ b/src/FlyITA.Web/Templates/TravelerProfiler.html
@@ -1,0 +1,315 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <title></title>
+    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+    <meta content="MSHTML 6.00.2900.3059" name="GENERATOR" />
+</head>
+<body>
+    <br />
+    <table style="font-size: 10pt; font-family: arial,sans-serif">
+        <tbody>
+            <tr>
+                <td>
+                    New User Traveler Profile information are as follows:
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <br />
+                </td>
+            </tr>
+            <tr></tr>
+            <tr>
+                <th colspan="2" style="text-align:left;font-size:1.1em;background-color:#dedede;">
+                    Traveler General Information
+                </th>
+
+            </tr>
+            <tr>
+                <td>
+                    Traveler First Name: [TravelerFirstName]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Traveler Middle Name: [TravelerMiddleName]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Traveler Last Name: [TravelerLastName]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Company Name: [CompanyName]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Title: [TravelerTitle]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Dept/Cost Center: [DeptCostCenter]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Email Address: [EmailAddress]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Business Phone: [BusinessPhone]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Business Fax: [BusinessFax]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Mobile Phone: [MobilePhone]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Home Phone: [HomePhone]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Date of Birth: [BirthDate]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Gender: [Gender]
+                </td>
+            </tr>
+            <tr>
+                <th colspan="2" style="text-align:left;font-size:1.1em;background-color:#dedede;">
+                    Passport Information
+                </th>
+
+
+            </tr>
+            <tr>
+                <td>
+                    Passport Name: [PassportName]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Passport Number: [PassportNumber]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Passport Issue Date: [PassportIssueDate]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Passport Expiration Date: [PassportExpirationDate]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Place of Issue: [PlaceofIssue]
+                </td>
+            </tr>
+            <tr>
+                <th colspan="2" style="text-align:left;font-size:1.1em;background-color:#dedede;">
+                    Traveler Arranger Information
+                </th>
+
+
+            </tr>
+            <tr>
+                <td>
+                    Traveler Arranger Name: [TravelerArrangerName]
+                </td>
+            </tr>
+            <tr>
+
+                <td>
+                    Traveler Arranger Phone: [TravelerArrangerPhone]
+                </td>
+            </tr>
+            <tr>
+
+                <td>
+                    Traveler Arranger Email: [TravelerArrangerEmail]
+                </td>
+            </tr>
+            <tr>
+                <th colspan="2" style="text-align:left;font-size:1.1em;background-color:#dedede;">
+                    Emergency Contact Information
+                </th>
+
+
+            </tr>
+            <tr>
+                <td>
+                    Emergency Contact Name: [EmergencyContactName]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Emergency Contact Relationship: [EmergencyContactRelationship]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Emergency Contact Phone: [EmergencyContactPhone]
+                </td>
+            </tr>
+            <tr>
+                <th colspan="2" style="text-align:left;font-size:1.1em;background-color:#dedede;">
+                    Travel Preferences
+                </th>
+
+
+            </tr>
+            <tr>
+                <td>
+                    Preferred Departure Airport: [PreferredDepartureAirport]
+                </td>
+            </tr>
+            <tr>
+
+                <td>
+                    Preferred Carrier: [PreferredCarrier]
+                </td>
+            </tr>
+            <tr>
+
+                <td>
+                    Other Preferred Carrier: [OtherPreferredCarrier]
+                </td>
+            </tr>
+            <tr>
+
+                <td>
+                    Seating Preference: [SeatingPreference]
+                </td>
+            </tr>
+            <tr>
+
+                <td>
+                    Special Meal Requirements: [SpecialMealRequirements]
+                </td>
+            </tr>
+
+            <frequentflyerti>
+                <tr>
+                    <td>
+                        Airlines<br>
+                        FrequentFlyer Number<br>
+
+                    </td>
+                    <td>
+                        <<frequentflyernumber>> <br>
+                            <<frequentflyernumberid>><br>
+
+                    </td>
+                </tr>
+            </frequentflyerti>
+            <tr>
+                <th colspan="2" style="text-align:left;font-size:1.1em;background-color:#dedede;">
+                    Hotel Preferences
+                </th>
+
+
+            </tr>
+            <tr>
+                <td>
+                    Smoking Preference: [SmokingPreference]
+                </td>
+            </tr>
+            <tr>
+
+                <td>
+                    Bed Preference: [BedPreference]
+                </td>
+            </tr>
+            <tr>
+
+                <td>
+                    Special Requirements: [SpecialRequirements]
+                </td>
+            </tr>
+            <hotelclubmembershipsti>
+                <tr>
+                    <td>
+                        Hotel Club Memberships<br>
+                        Hotel Club Memberships Number<br>
+
+                    </td>
+                    <td>
+                        <<hotelclubmemberships>> <br>
+                            <<hotelclubmembershipsid>><br>
+
+                    </td>
+                </tr>
+            </hotelclubmembershipsti>
+            <tr>
+                <td>
+                    Other Hotel Membership: [OtherHotelMembership]
+                </td>
+
+            </tr>
+            <tr>
+                <td>
+                    Other Hotel Membership Number: [OtherHotelMembershipNumber]
+                </td>
+
+            </tr>
+
+            <tr>
+                <th colspan="2" style="text-align:left;font-size:1.1em;background-color:#dedede;">
+                    Rental Car Preferences
+                </th>
+
+
+
+            </tr>
+            <tr>
+                <td>
+                    Vehicle Size : [VehicleSize]
+                </td>
+            </tr>
+            <rentalcarmembershipsti>
+                <tr>
+                    <td>
+                        Rental Car Memberships<br>
+                        Rental Car Memberships Number<br>
+
+
+                    </td>
+                    <td>
+                        <<rentalcarmemberships>> <br>
+                            <<rentalcarmembershipsid>><br>
+
+                    </td>
+                </tr>
+            </rentalcarmembershipsti>
+            <tr>
+                <td>
+                    <br />
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Thank you.
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</body>
+</html>

--- a/src/FlyITA.Web/Templates/TravelerProfiler.html
+++ b/src/FlyITA.Web/Templates/TravelerProfiler.html
@@ -11,7 +11,7 @@
         <tbody>
             <tr>
                 <td>
-                    New User Traveler Profile information are as follows:
+                    New User Traveler Profile information is as follows:
                 </td>
             </tr>
             <tr>

--- a/src/FlyITA.Web/Templates/VacationTravelRequest.html
+++ b/src/FlyITA.Web/Templates/VacationTravelRequest.html
@@ -11,7 +11,7 @@
         <tbody>
             <tr>
                 <td>
-                    New User Traveler Profile information are as follows:
+                    Vacation Travel Request information is as follows:
                 </td>
             </tr>
             <tr>

--- a/src/FlyITA.Web/Templates/VacationTravelRequest.html
+++ b/src/FlyITA.Web/Templates/VacationTravelRequest.html
@@ -1,0 +1,182 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <title></title>
+    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+    <meta content="MSHTML 6.00.2900.3059" name="GENERATOR" />
+</head>
+<body>
+    <br />
+    <table style="font-size: 10pt; font-family: arial,sans-serif">
+        <tbody>
+            <tr>
+                <td>
+                    New User Traveler Profile information are as follows:
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <br />
+                </td>
+            </tr>
+            <tr></tr>
+            <tr>
+                <th colspan="2" style="text-align:left;font-size:1.1em;background-color:#dedede;">
+                    General and Passenger Information
+                </th>
+            </tr>
+            <tr>
+                <td>
+                    Name of Person Requesting: [NameofPersonRequesting]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Email Address: [GeneralandPassengerEmail]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Phone Number: [PhoneNumber]
+                </td>
+            </tr>
+            <!--<tr>
+                <td>
+                    Passenger First Name: [PassengerFirstName]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Passenger Last Name: [PassengerLastName]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Date of Birth: [BirthDate]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Gender: [Gender]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Passport Number: [PassportNumber]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Passport Expiration Date: [PassportExpirationDate]
+                </td>
+            </tr>-->
+            <passengerinfoi>
+                <tr>
+                    <td>
+                        Passenger First Name<br>
+                        Passenger Middle Name<br>
+                        Passenger Last Name<br>
+                        Date of Birth<br>
+                        Gender<br>
+                        Passport Number<br>
+                        Passport Expiration Date<br>
+                    </td>
+                    <td>
+                        <<pfirstname>>
+                            <br>
+                            <<pmiddlename>>
+                                <br>
+                                <<plastname>>
+                                    <br>
+                                    <<pdob>>
+                                        <br>
+                                        <<pgender>>
+                                            <br>
+                                            <<ppassportnumber>>
+                                                <br>
+                                                <<ppassportexp>>
+                                                    <br>
+                    </td>
+                </tr>
+            </passengerinfoi>
+            <tr>
+                <th colspan="2" style="text-align: left; font-size: 1.1em; background-color: #dedede;">
+                    Frequent Flyer Information
+                </th>
+
+            </tr>
+            <!--<tr>
+                <td>Airline: [Airline]</td>
+            </tr>-->
+            <frequentflyerti>
+                <tr>
+                    <td>
+                        Airlines<br>
+                        FrequentFlyer Number<br>
+                    </td>
+                    <td>
+                        <<frequentflyernumber>> <br>
+                            <<frequentflyernumberid>><br>
+                    </td>
+                </tr>
+            </frequentflyerti>
+
+            <tr>
+                <th colspan="2" style="text-align:left;font-size:1.1em;background-color:#dedede;">
+                    Trip Information
+                </th>
+
+            </tr>
+            <tr>
+                <td>
+                    Departure City : [DepartureCity]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Preferred Airline : [PreferredAirline]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Destinations Interested In : [DestinationsInterestedIn]
+                </td>
+            </tr>
+
+            <tr>
+                <td>
+                    Preferred Dates of Travel : [PreferredDatesofTravel]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Destinations Not Interested In : [DestinationsNotInterestedIn]
+                </td>
+            </tr>
+
+
+            <tr>
+                <td>
+                    Tell us a little about what you like to do while on vacation?: [VacationDetails]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    What amenities are important to you in your hotel?: [ImportantAmenities]
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    How many rooms are needed?: [RoomsNeeded]
+                </td>
+            </tr>
+
+            <tr>
+                <td>
+                    Thank you.
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</body>
+</html>

--- a/src/FlyITA.Web/appsettings.json
+++ b/src/FlyITA.Web/appsettings.json
@@ -22,8 +22,8 @@
     "LogonCredentialsTemplate": "",
     "SeamlessLogonCredentialsTemplate": "",
     "ThirdPartyEmailTemplate": "",
-    "TravelerProfileTemplate": "",
-    "VacationTravelRequestTemplate": "",
+    "TravelerProfileTemplate": "TravelerProfiler.html",
+    "VacationTravelRequestTemplate": "VacationTravelRequest.html",
     "ThirdPartyFromEmail": "",
     "ThirdPartyToEmail": "",
     "ThirdPartySubject": ""

--- a/tests/FlyITA.Core.Tests/Services/EmailServiceTests.cs
+++ b/tests/FlyITA.Core.Tests/Services/EmailServiceTests.cs
@@ -2,6 +2,7 @@ using Moq;
 using Microsoft.Extensions.Configuration;
 using FlyITA.Core.Abstractions;
 using FlyITA.Core.Interfaces;
+using FlyITA.Core.Models;
 using FlyITA.Core.Services;
 
 namespace FlyITA.Core.Tests.Services;
@@ -11,51 +12,17 @@ public class EmailServiceTests
     private readonly Mock<IContextManager> _contextMock = new();
     private readonly Mock<IPCentralDataAccess> _dataMock = new();
     private readonly Mock<ISmtpClient> _smtpMock = new();
+    private readonly Mock<IEmailTemplateLoader> _templateMock = new();
 
     private EmailService CreateService(Dictionary<string, string?>? configPairs = null)
     {
         var config = new ConfigurationBuilder()
             .AddInMemoryCollection(configPairs ?? new())
             .Build();
-        return new EmailService(_contextMock.Object, _dataMock.Object, config, _smtpMock.Object);
+        return new EmailService(_contextMock.Object, _dataMock.Object, config, _smtpMock.Object, _templateMock.Object);
     }
 
-    [Fact]
-    public async Task ReplacePlaceholdersAsync_Replaces_Name()
-    {
-        var service = CreateService();
-        _contextMock.SetupGet(c => c.ProgramID).Returns(1);
-        _dataMock.Setup(d => d.GetProgramByIdAsync(1)).ReturnsAsync(new Dictionary<string, object?>());
-
-        var participant = new Dictionary<string, object?>
-        {
-            ["LegalFirstName"] = "John",
-            ["LegalLastName"] = "Doe",
-            ["EmailAddress"] = "john@test.com"
-        };
-
-        var body = "Hello <<LegalFirstName>> <<LegalLastName>>, email: <<EmailAddress>>";
-        var result = await service.ReplacePlaceholdersAsync(body, participant);
-
-        Assert.Equal("Hello John Doe, email: john@test.com", result);
-    }
-
-    [Fact]
-    public async Task ReplacePlaceholdersAsync_Replaces_Participant_Name_Token()
-    {
-        var service = CreateService();
-        _contextMock.SetupGet(c => c.ProgramID).Returns(1);
-        _dataMock.Setup(d => d.GetProgramByIdAsync(1)).ReturnsAsync(new Dictionary<string, object?>());
-
-        var participant = new Dictionary<string, object?>
-        {
-            ["LegalFirstName"] = "Jane",
-            ["LegalLastName"] = "Smith"
-        };
-
-        var result = await service.ReplacePlaceholdersAsync("Dear [PARTICIPANT_NAME]", participant);
-        Assert.Equal("Dear Jane Smith", result);
-    }
+    // Standard email tests
 
     [Fact]
     public async Task SendRegistrationConfirmation_Fails_When_No_Participant()
@@ -71,7 +38,7 @@ public class EmailServiceTests
     public async Task SendRegistrationConfirmation_Fails_When_No_Template()
     {
         _dataMock.Setup(d => d.GetParticipantByIdAsync(1)).ReturnsAsync(new Dictionary<string, object?> { ["EmailAddress"] = "test@test.com" });
-        _dataMock.Setup(d => d.GetEmailTemplateAsync(It.IsAny<string>(), It.IsAny<int>())).ReturnsAsync((string?)null);
+        _templateMock.Setup(t => t.LoadTemplateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync((string?)null);
 
         var result = await CreateService().SendRegistrationConfirmationAsync(1);
         Assert.False(result.IsValid);
@@ -83,10 +50,147 @@ public class EmailServiceTests
     {
         _contextMock.SetupGet(c => c.ProgramID).Returns(1);
         _dataMock.Setup(d => d.GetParticipantByIdAsync(1)).ReturnsAsync(new Dictionary<string, object?> { ["LegalFirstName"] = "Test", ["LegalLastName"] = "User" });
-        _dataMock.Setup(d => d.GetEmailTemplateAsync(It.IsAny<string>(), 1)).ReturnsAsync("<p>Hello <<LegalFirstName>></p>");
+        _templateMock.Setup(t => t.LoadTemplateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync("<p>Hello <<LegalFirstName>></p>");
         _dataMock.Setup(d => d.GetProgramByIdAsync(1)).ReturnsAsync(new Dictionary<string, object?>());
 
         var html = await CreateService().PreviewLogonCredentialsAsync(1);
         Assert.Contains("<p>Hello Test</p>", html);
+    }
+
+    // Vacation email tests
+
+    [Fact]
+    public async Task SendVacationRequest_Success_ReplacesTokensAndSends()
+    {
+        _templateMock.Setup(t => t.LoadTemplateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("Name: [NameofPersonRequesting], Phone: [PhoneNumber], City: [DepartureCity]");
+
+        var data = new VacationEmailData
+        {
+            ToEmail = "to@test.com",
+            FromEmail = "from@test.com",
+            Subject = "Vacation Request",
+            NameOfPersonRequesting = "Alice",
+            PhoneNumber = "555-1234",
+            DepartureCity = "Chicago"
+        };
+
+        var result = await CreateService().SendVacationRequestEmailAsync(data);
+
+        Assert.True(result.IsValid);
+        _smtpMock.Verify(s => s.SendAsync(
+            It.Is<System.Net.Mail.MailMessage>(m =>
+                m.Body.Contains("Alice") &&
+                m.Body.Contains("555-1234") &&
+                m.Body.Contains("Chicago")),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SendVacationRequest_ProcessesPassengerBlock()
+    {
+        _templateMock.Setup(t => t.LoadTemplateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("Before<passengerinfoi><<pfirstname>> <<plastname>></passengerinfoi>After");
+
+        var data = new VacationEmailData
+        {
+            ToEmail = "to@test.com",
+            FromEmail = "from@test.com",
+            Subject = "Test",
+            Passengers = new List<PassengerData>
+            {
+                new() { FirstName = "Bob", LastName = "Smith" },
+                new() { FirstName = "Eve", LastName = "Jones" }
+            }
+        };
+
+        var result = await CreateService().SendVacationRequestEmailAsync(data);
+
+        Assert.True(result.IsValid);
+        _smtpMock.Verify(s => s.SendAsync(
+            It.Is<System.Net.Mail.MailMessage>(m =>
+                m.Body.Contains("Bob") && m.Body.Contains("Eve") &&
+                !m.Body.Contains("<passengerinfoi>")),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SendVacationRequest_Fails_When_No_Template()
+    {
+        _templateMock.Setup(t => t.LoadTemplateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync((string?)null);
+
+        var data = new VacationEmailData { ToEmail = "to@test.com", FromEmail = "from@test.com" };
+        var result = await CreateService().SendVacationRequestEmailAsync(data);
+
+        Assert.False(result.IsValid);
+        Assert.Contains("template not found", result.Errors[0]);
+    }
+
+    [Fact]
+    public async Task SendVacationRequest_Fails_When_NoRouting()
+    {
+        _templateMock.Setup(t => t.LoadTemplateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync("<html></html>");
+
+        var data = new VacationEmailData { ToEmail = "", FromEmail = "" };
+        var result = await CreateService().SendVacationRequestEmailAsync(data);
+
+        Assert.False(result.IsValid);
+        Assert.Contains("routing not configured", result.Errors[0]);
+    }
+
+    // Traveler profile form email tests
+
+    [Fact]
+    public async Task SendTravelerProfileForm_Success_ReplacesTokensAndSends()
+    {
+        _templateMock.Setup(t => t.LoadTemplateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("Name: [TravelerFirstName] [TravelerLastName], Co: [CompanyName]");
+
+        var data = new TravelerProfileEmailData
+        {
+            ToEmail = "to@test.com",
+            FromEmail = "from@test.com",
+            Subject = "Profile",
+            TravelerFirstName = "John",
+            TravelerLastName = "Doe",
+            CompanyName = "Acme"
+        };
+
+        var result = await CreateService().SendTravelerProfileFormEmailAsync(data);
+
+        Assert.True(result.IsValid);
+        _smtpMock.Verify(s => s.SendAsync(
+            It.Is<System.Net.Mail.MailMessage>(m =>
+                m.Body.Contains("John") &&
+                m.Body.Contains("Doe") &&
+                m.Body.Contains("Acme")),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SendTravelerProfileForm_ProcessesFrequentFlyerBlock()
+    {
+        _templateMock.Setup(t => t.LoadTemplateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("<frequentflyerti><<frequentflyernumber>>:<<frequentflyernumberid>></frequentflyerti>");
+
+        var data = new TravelerProfileEmailData
+        {
+            ToEmail = "to@test.com",
+            FromEmail = "from@test.com",
+            Subject = "Test",
+            FrequentFlyers = new List<FrequentFlyerData>
+            {
+                new() { Airline = "Delta", Number = "123456" }
+            }
+        };
+
+        var result = await CreateService().SendTravelerProfileFormEmailAsync(data);
+
+        Assert.True(result.IsValid);
+        _smtpMock.Verify(s => s.SendAsync(
+            It.Is<System.Net.Mail.MailMessage>(m =>
+                m.Body.Contains("Delta") && m.Body.Contains("123456") &&
+                !m.Body.Contains("<frequentflyerti>")),
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/tests/FlyITA.Core.Tests/Services/EmailTemplateEngineTests.cs
+++ b/tests/FlyITA.Core.Tests/Services/EmailTemplateEngineTests.cs
@@ -1,0 +1,190 @@
+using FlyITA.Core.Services;
+
+namespace FlyITA.Core.Tests.Services;
+
+public class EmailTemplateEngineTests
+{
+    [Fact]
+    public void ReplaceParticipantTokens_ReplacesAllKnownTokens()
+    {
+        var participant = new Dictionary<string, object?>
+        {
+            ["LegalFirstName"] = "John",
+            ["LegalMiddleName"] = "M",
+            ["LegalLastName"] = "Doe",
+            ["DateOfBirth"] = "01/15/1990",
+            ["Gender"] = "Male",
+            ["EmailAddress"] = "john@test.com",
+            ["UserName"] = "jdoe",
+            ["Password"] = "secret"
+        };
+
+        var body = "Hello <<LegalFirstName>> <<LegalMiddleName>> <<LegalLastName>>, DOB: <<DateOfBirth>>, " +
+                   "Gender: <<Gender>>, Email: <<EmailAddress>>, " +
+                   "Name: [PARTICIPANT_NAME], User: [PARTICIPANT_USERNAME], Pass: [PARTICIPANT_PASSWORD]";
+
+        var result = EmailTemplateEngine.ReplaceParticipantTokens(body, participant);
+
+        Assert.Contains("John", result);
+        Assert.Contains("Doe", result);
+        Assert.Contains("01/15/1990", result);
+        Assert.Contains("Male", result);
+        Assert.Contains("john@test.com", result);
+        Assert.Contains("jdoe", result);
+        Assert.Contains("secret", result);
+        Assert.Contains("John Doe", result); // [PARTICIPANT_NAME]
+        Assert.DoesNotContain("<<", result);
+        Assert.DoesNotContain("[PARTICIPANT_", result);
+    }
+
+    [Fact]
+    public void ReplaceParticipantTokens_MissingKeys_ReplacesWithEmpty()
+    {
+        var participant = new Dictionary<string, object?> { ["LegalFirstName"] = "Jane" };
+        var body = "<<LegalFirstName>> <<LegalLastName>>";
+
+        var result = EmailTemplateEngine.ReplaceParticipantTokens(body, participant);
+
+        Assert.Equal("Jane ", result);
+    }
+
+    [Fact]
+    public void ReplaceProgramTokens_ReplacesAllKnownTokens()
+    {
+        var program = new Dictionary<string, object?>
+        {
+            ["ProgramName"] = "Rewards 2026",
+            ["ProgramTollFreeNbr"] = "800-555-1234",
+            ["TravelHeadquartersName"] = "ITA Group",
+            ["WebRegistrationSiteUrl"] = "https://register.example.com",
+            ["FromEmailAddress"] = "noreply@example.com"
+        };
+
+        var body = "[PROGRAM_NAME] [PROGRAM_800NBR] [PROGRAM_HQNAME] [PROGRAM_URL] [PROGRAM_EMAIL]";
+
+        var result = EmailTemplateEngine.ReplaceProgramTokens(body, program);
+
+        Assert.Equal("Rewards 2026 800-555-1234 ITA Group https://register.example.com noreply@example.com", result);
+    }
+
+    [Fact]
+    public void ReplaceFormFieldTokens_ReplacesMatchingKeys()
+    {
+        var fields = new Dictionary<string, string>
+        {
+            ["NameofPersonRequesting"] = "Alice",
+            ["PhoneNumber"] = "555-1234"
+        };
+
+        var body = "Name: [NameofPersonRequesting], Phone: [PhoneNumber], City: [DepartureCity]";
+
+        var result = EmailTemplateEngine.ReplaceFormFieldTokens(body, fields);
+
+        Assert.Contains("Alice", result);
+        Assert.Contains("555-1234", result);
+        Assert.Contains("[DepartureCity]", result); // Not in fields, left as-is
+    }
+
+    [Fact]
+    public void ReplaceCustomFieldTokens_ReplacesMatchingFields()
+    {
+        var fields = new List<Dictionary<string, object?>>
+        {
+            new() { ["Name"] = "Title", ["Value"] = "VP" },
+            new() { ["Name"] = "Department", ["Value"] = "Sales" }
+        };
+
+        var body = "Title: <<CustomField.Title>>, Dept: <<CustomField.Department>>";
+
+        var result = EmailTemplateEngine.ReplaceCustomFieldTokens(body, fields);
+
+        Assert.Equal("Title: VP, Dept: Sales", result);
+    }
+
+    [Fact]
+    public void ReplaceCustomFieldTokens_NoCustomFields_ReturnsUnchanged()
+    {
+        var body = "No custom fields here";
+        var result = EmailTemplateEngine.ReplaceCustomFieldTokens(body, new List<Dictionary<string, object?>>());
+        Assert.Equal("No custom fields here", result);
+    }
+
+    [Fact]
+    public void ProcessRepeatingBlock_MultipleItems_ExpandsBlock()
+    {
+        var body = "Before<passengerinfoi>Name: <<pfirstname>> <<plastname>>\n</passengerinfoi>After";
+        var items = new List<Dictionary<string, string>>
+        {
+            new() { ["<<pfirstname>>"] = "Alice", ["<<plastname>>"] = "Smith" },
+            new() { ["<<pfirstname>>"] = "Bob", ["<<plastname>>"] = "Jones" }
+        };
+
+        var result = EmailTemplateEngine.ProcessRepeatingBlock(body, "<passengerinfoi>", "</passengerinfoi>", items);
+
+        Assert.Contains("Alice", result);
+        Assert.Contains("Bob", result);
+        Assert.Contains("Smith", result);
+        Assert.Contains("Jones", result);
+        Assert.DoesNotContain("<passengerinfoi>", result);
+        Assert.DoesNotContain("</passengerinfoi>", result);
+    }
+
+    [Fact]
+    public void ProcessRepeatingBlock_ZeroItems_RemovesBlock()
+    {
+        var body = "Before<passengerinfoi>Name: <<pfirstname>>\n</passengerinfoi>After";
+        var items = new List<Dictionary<string, string>>();
+
+        var result = EmailTemplateEngine.ProcessRepeatingBlock(body, "<passengerinfoi>", "</passengerinfoi>", items);
+
+        Assert.Equal("BeforeAfter", result);
+        Assert.DoesNotContain("<<pfirstname>>", result);
+    }
+
+    [Fact]
+    public void ProcessRepeatingBlock_NoMarkers_ReturnsSameBody()
+    {
+        var body = "No blocks here";
+        var items = new List<Dictionary<string, string>> { new() { ["<<x>>"] = "y" } };
+
+        var result = EmailTemplateEngine.ProcessRepeatingBlock(body, "<block>", "</block>", items);
+
+        Assert.Equal("No blocks here", result);
+    }
+
+    [Fact]
+    public void ReplaceContactTokens_MapsToCorrectPhoneTypes()
+    {
+        var contacts = new List<Dictionary<string, object?>>
+        {
+            new() { ["ContactType"] = "Business", ["ContactNumber"] = "555-0001" },
+            new() { ["ContactType"] = "Fax", ["ContactNumber"] = "555-0002" },
+            new() { ["ContactType"] = "Mobile", ["ContactNumber"] = "555-0003" },
+            new() { ["ContactType"] = "Home", ["ContactNumber"] = "555-0004" }
+        };
+
+        var body = "Bus: <<BusinessPhone>>, Fax: <<BusinessFax>>, Mob: <<MobilePhone>>, Home: <<HomePhone>>";
+
+        var result = EmailTemplateEngine.ReplaceContactTokens(body, contacts);
+
+        Assert.Equal("Bus: 555-0001, Fax: 555-0002, Mob: 555-0003, Home: 555-0004", result);
+    }
+
+    [Fact]
+    public void ReplaceTransportationTokens_ReplacesAllTravelFields()
+    {
+        var transport = new Dictionary<string, object?>
+        {
+            ["TransportationType"] = "Air",
+            ["SeatPreference"] = "Window",
+            ["CheckInDate"] = "03/15/2026",
+            ["CheckOutDate"] = "03/20/2026"
+        };
+
+        var body = "Type: <<TransportationType>>, Seat: <<SeatPreference>>, In: <<CheckInDate>>, Out: <<CheckOutDate>>";
+
+        var result = EmailTemplateEngine.ReplaceTransportationTokens(body, transport);
+
+        Assert.Equal("Type: Air, Seat: Window, In: 03/15/2026, Out: 03/20/2026", result);
+    }
+}

--- a/tests/FlyITA.Web.Tests/Services/FileEmailTemplateLoaderTests.cs
+++ b/tests/FlyITA.Web.Tests/Services/FileEmailTemplateLoaderTests.cs
@@ -1,0 +1,72 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
+using FlyITA.Core.Abstractions;
+using FlyITA.Core.Interfaces;
+using FlyITA.Web.Services;
+
+namespace FlyITA.Web.Tests.Services;
+
+public class FileEmailTemplateLoaderTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly Mock<IWebHostEnvironment> _envMock = new();
+    private readonly Mock<IPCentralDataAccess> _dataMock = new();
+    private readonly Mock<IContextManager> _contextMock = new();
+    private readonly Mock<ILogger<FileEmailTemplateLoader>> _loggerMock = new();
+
+    public FileEmailTemplateLoaderTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"flyita_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(_tempDir, "Templates"));
+        _envMock.SetupGet(e => e.ContentRootPath).Returns(_tempDir);
+        _contextMock.SetupGet(c => c.ProgramID).Returns(1);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [Fact]
+    public async Task LoadTemplate_FileExists_ReturnsFileContent()
+    {
+        var templatePath = Path.Combine(_tempDir, "Templates", "test.html");
+        await File.WriteAllTextAsync(templatePath, "<html>Hello</html>");
+
+        var loader = new FileEmailTemplateLoader(_envMock.Object, _dataMock.Object, _contextMock.Object, _loggerMock.Object);
+
+        var result = await loader.LoadTemplateAsync("test.html");
+
+        Assert.Equal("<html>Hello</html>", result);
+        _dataMock.Verify(d => d.GetEmailTemplateAsync(It.IsAny<string>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task LoadTemplate_FileMissing_FallsBackToSidecar()
+    {
+        _dataMock.Setup(d => d.GetEmailTemplateAsync("missing.html", 1))
+            .ReturnsAsync("<html>From sidecar</html>");
+
+        var loader = new FileEmailTemplateLoader(_envMock.Object, _dataMock.Object, _contextMock.Object, _loggerMock.Object);
+
+        var result = await loader.LoadTemplateAsync("missing.html");
+
+        Assert.Equal("<html>From sidecar</html>", result);
+        _dataMock.Verify(d => d.GetEmailTemplateAsync("missing.html", 1), Times.Once);
+    }
+
+    [Fact]
+    public async Task LoadTemplate_BothMissing_ReturnsNull()
+    {
+        _dataMock.Setup(d => d.GetEmailTemplateAsync("nowhere.html", 1))
+            .ReturnsAsync((string?)null);
+
+        var loader = new FileEmailTemplateLoader(_envMock.Object, _dataMock.Object, _contextMock.Object, _loggerMock.Object);
+
+        var result = await loader.LoadTemplateAsync("nowhere.html");
+
+        Assert.Null(result);
+    }
+}


### PR DESCRIPTION
## Summary
- **Port legacy template system** — file-based HTML templates with 40+ token replacements, matching `CustomEmails.cs` behavior
- **EmailTemplateEngine** — static utility with participant/program/form field/custom field/contact/transportation token replacement + generic repeating block processor
- **FileEmailTemplateLoader** — loads templates from local files first, falls back to sidecar for program-specific templates
- **Vacation page** — replaced hardcoded `BuildEmailBody()` HTML with template-based email via `VacationTravelRequest.html`
- **TravelerProfile page** — wired to send third-party email on submit via `TravelerProfiler.html` template

## Key Design Decisions
- Templates loaded from `Templates/` folder (file I/O), not sidecar — matching legacy behavior
- Only 2 templates in source (Vacation, TravelerProfile); standard email templates (registration, logon) are program-specific, deployed per-environment
- Email routing (to/from/subject) passed from page → EmailService via data models (EmailService is in Core, can't access Web-layer options)

## Test plan
- [x] 11 unit tests for EmailTemplateEngine (tokens, blocks, contacts, transport)
- [x] 9 unit tests for EmailService (standard emails + vacation + traveler profile)
- [x] 3 unit tests for FileEmailTemplateLoader (file, sidecar fallback, null)
- [x] 165 existing web tests pass (including FormPageTests)
- [x] 285 total tests, 0 warnings, 0 errors
- [ ] SMTP delivery testing blocked on SMTP server access

🤖 Generated with [Claude Code](https://claude.com/claude-code)