### PR TITLE
feat: add CI/CD pipelines for modern .NET 10 app (#30)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -16,8 +16,7 @@ jobs:
       - name: Setup .NET 10
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '10.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: '10.x'
 
       - name: Restore
         run: dotnet restore FlyITA.Modern.sln
@@ -25,22 +24,19 @@ jobs:
       - name: Build
         run: dotnet build FlyITA.Modern.sln --configuration Release --no-restore
 
-      - name: Unit Tests
-        run: dotnet test tests/FlyITA.Core.Tests --configuration Release --no-build --logger trx --collect:"XPlat Code Coverage"
-
-      - name: Integration Tests
-        run: dotnet test tests/FlyITA.Web.Tests --configuration Release --no-build --logger trx --collect:"XPlat Code Coverage"
+      - name: Test (Unit + Integration)
+        run: dotnet test FlyITA.Modern.sln --configuration Release --no-build --filter "FullyQualifiedName!~E2E" --logger trx --results-directory TestResults --collect:"XPlat Code Coverage"
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-results
-          path: '**/*.trx'
+          path: TestResults/**/*.trx
 
       - name: Upload Coverage
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: coverage
-          path: '**/coverage.cobertura.xml'
+          path: TestResults/**/coverage.cobertura.xml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,11 +80,11 @@ stages:
               projects: '$(publishProject)'
               arguments: '--configuration $(buildConfiguration) --no-build --output $(Build.ArtifactStagingDirectory)/web'
 
-          - task: PublishBuildArtifacts@1
+          - task: PublishPipelineArtifact@1
             displayName: 'Upload Artifact'
             inputs:
-              PathtoPublish: '$(Build.ArtifactStagingDirectory)/web'
-              ArtifactName: 'FlyITA.Web'
+              targetPath: '$(Build.ArtifactStagingDirectory)/web'
+              artifact: 'FlyITA.Web'
 
   # ─── Stage 2: Deploy to Dev ───
   - stage: Dev
@@ -101,6 +101,9 @@ stages:
           runOnce:
             deploy:
               steps:
+                - download: current
+                  artifact: 'FlyITA.Web'
+
                 - task: CopyFiles@2
                   displayName: 'Copy to IIS (Dev)'
                   inputs:
@@ -124,6 +127,9 @@ stages:
           runOnce:
             deploy:
               steps:
+                - download: current
+                  artifact: 'FlyITA.Web'
+
                 - task: CopyFiles@2
                   displayName: 'Copy to IIS (Test)'
                   inputs:
@@ -147,6 +153,9 @@ stages:
           runOnce:
             deploy:
               steps:
+                - download: current
+                  artifact: 'FlyITA.Web'
+
                 - task: CopyFiles@2
                   displayName: 'Copy to IIS (Prod)'
                   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,157 @@
+# FlyITA Modern — CI/CD Pipeline
+# Replaces legacy build #837 + release #197 for the .NET 10 app
+#
+# Build pipeline: restore → build → test → publish artifact
+# Release stages: Dev → Test → Prod (file copy to IIS, matching legacy pattern)
+
+trigger:
+  branches:
+    include:
+      - master
+  paths:
+    include:
+      - src/FlyITA.Web/**
+      - src/FlyITA.Core/**
+      - src/FlyITA.Infrastructure/**
+      - tests/**
+      - FlyITA.Modern.sln
+
+pr:
+  branches:
+    include:
+      - master
+
+pool:
+  name: BUILDAGENTS
+
+variables:
+  solution: 'FlyITA.Modern.sln'
+  buildConfiguration: 'Release'
+  dotnetVersion: '10.x'
+  publishProject: 'src/FlyITA.Web/FlyITA.Web.csproj'
+
+stages:
+  # ─── Stage 1: Build + Test ───
+  - stage: Build
+    displayName: 'Build & Test'
+    jobs:
+      - job: BuildAndTest
+        displayName: 'Restore → Build → Test → Publish'
+        steps:
+          - task: UseDotNet@2
+            displayName: 'Install .NET 10 SDK'
+            inputs:
+              packageType: 'sdk'
+              version: '$(dotnetVersion)'
+              installationPath: $(Agent.ToolsDirectory)/dotnet
+
+          - task: DotNetCoreCLI@2
+            displayName: 'Restore'
+            inputs:
+              command: 'restore'
+              projects: '$(solution)'
+
+          - task: DotNetCoreCLI@2
+            displayName: 'Build'
+            inputs:
+              command: 'build'
+              projects: '$(solution)'
+              arguments: '--configuration $(buildConfiguration) --no-restore'
+
+          - task: DotNetCoreCLI@2
+            displayName: 'Test (Unit + Integration)'
+            inputs:
+              command: 'test'
+              projects: '$(solution)'
+              arguments: '--configuration $(buildConfiguration) --no-build --filter "FullyQualifiedName!~E2E" --logger trx --results-directory $(Agent.TempDirectory)/TestResults'
+
+          - task: PublishTestResults@2
+            displayName: 'Publish Test Results'
+            inputs:
+              testResultsFormat: 'VSTest'
+              testResultsFiles: '$(Agent.TempDirectory)/TestResults/*.trx'
+              mergeTestResults: true
+            condition: succeededOrFailed()
+
+          - task: DotNetCoreCLI@2
+            displayName: 'Publish Web App'
+            inputs:
+              command: 'publish'
+              projects: '$(publishProject)'
+              arguments: '--configuration $(buildConfiguration) --no-build --output $(Build.ArtifactStagingDirectory)/web'
+
+          - task: PublishBuildArtifacts@1
+            displayName: 'Upload Artifact'
+            inputs:
+              PathtoPublish: '$(Build.ArtifactStagingDirectory)/web'
+              ArtifactName: 'FlyITA.Web'
+
+  # ─── Stage 2: Deploy to Dev ───
+  - stage: Dev
+    displayName: 'Deploy to Dev'
+    dependsOn: Build
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    variables:
+      deployPath: '\\itagroup\web\dev\publish\dev.flyita.com'
+    jobs:
+      - deployment: DeployDev
+        displayName: 'Deploy to dev.flyita.com'
+        environment: 'FlyITA-Dev'
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - task: CopyFiles@2
+                  displayName: 'Copy to IIS (Dev)'
+                  inputs:
+                    SourceFolder: '$(Pipeline.Workspace)/FlyITA.Web'
+                    Contents: '**'
+                    TargetFolder: '$(deployPath)'
+                    CleanTargetFolder: false
+                    OverWrite: true
+
+  # ─── Stage 3: Deploy to Test ───
+  - stage: Test
+    displayName: 'Deploy to Test'
+    dependsOn: Dev
+    variables:
+      deployPath: '\\itagroup\web\test\publish\test.flyita.com'
+    jobs:
+      - deployment: DeployTest
+        displayName: 'Deploy to test.flyita.com'
+        environment: 'FlyITA-Test'
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - task: CopyFiles@2
+                  displayName: 'Copy to IIS (Test)'
+                  inputs:
+                    SourceFolder: '$(Pipeline.Workspace)/FlyITA.Web'
+                    Contents: '**'
+                    TargetFolder: '$(deployPath)'
+                    CleanTargetFolder: false
+                    OverWrite: true
+
+  # ─── Stage 4: Deploy to Prod ───
+  - stage: Prod
+    displayName: 'Deploy to Prod'
+    dependsOn: Test
+    variables:
+      deployPath: '\\itagroup\web\prod\publish\www.flyita.com'
+    jobs:
+      - deployment: DeployProd
+        displayName: 'Deploy to www.flyita.com'
+        environment: 'FlyITA-Prod'
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - task: CopyFiles@2
+                  displayName: 'Copy to IIS (Prod)'
+                  inputs:
+                    SourceFolder: '$(Pipeline.Workspace)/FlyITA.Web'
+                    Contents: '**'
+                    TargetFolder: '$(deployPath)'
+                    CleanTargetFolder: false
+                    OverWrite: true


### PR DESCRIPTION
## Summary
- **Azure DevOps pipeline** (`azure-pipelines.yml`) — full CI/CD matching legacy pattern
  - Build: .NET 10 SDK → restore → build → test (excl E2E) → publish artifact
  - Deploy: Dev → Test → Prod (file copy to IIS UNC paths)
- **GitHub Actions** (`.github/workflows/ci.yml`) — updated for PR checks
  - windows-latest, .NET 10, single test run with coverage

## Azure DevOps Setup
After merging, in Azure DevOps:
1. Go to Pipelines → New Pipeline → Azure Repos Git → FlyITA → Existing YAML → `azure-pipelines.yml`
2. Create environments: `FlyITA-Dev`, `FlyITA-Test`, `FlyITA-Prod` (add approval gates on Prod)
3. Verify BUILDAGENTS pool has .NET 10 SDK installed
4. Verify UNC deploy paths are accessible from build agents

## Deploy paths (matching legacy)
| Env | Path |
|-----|------|
| Dev | `\itagroup\web\dev\publish\dev.flyita.com` |
| Test | `\itagroup\web\test\publish\test.flyita.com` |
| Prod | `\itagroup\web\prod\publish\www.flyita.com` |

## Test plan
- [x] YAML syntax valid
- [x] Solution builds locally with 0 warnings
- [ ] Azure DevOps pipeline runs (needs agent with .NET 10 SDK)
- [ ] GitHub Actions runs on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)