### PR TITLE
feat: add Playwright browser install + E2E tests to CI (#31)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,13 @@ jobs:
       - name: Test (Unit + Integration)
         run: dotnet test FlyITA.Modern.sln --configuration Release --no-build --filter "FullyQualifiedName!~E2E" --logger trx --results-directory TestResults --collect:"XPlat Code Coverage"
 
+      - name: Install Playwright Chromium
+        run: pwsh tests/FlyITA.E2E.Tests/bin/Release/net10.0/playwright.ps1 install chromium
+
+      - name: E2E Tests (Playwright)
+        run: dotnet test tests/FlyITA.E2E.Tests --configuration Release --no-build --logger trx --results-directory TestResults/E2E
+        continue-on-error: true
+
       - name: Upload Test Results
         uses: actions/upload-artifact@v4
         if: always()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,6 +74,30 @@ stages:
             condition: succeededOrFailed()
 
           - task: DotNetCoreCLI@2
+            displayName: 'Build E2E Tests'
+            inputs:
+              command: 'build'
+              projects: 'tests/FlyITA.E2E.Tests/FlyITA.E2E.Tests.csproj'
+              arguments: '--configuration $(buildConfiguration) --no-restore'
+
+          - pwsh: |
+              $playwrightPs1 = Get-ChildItem -Path "tests/FlyITA.E2E.Tests/bin" -Recurse -Filter "playwright.ps1" | Select-Object -First 1
+              if ($playwrightPs1) {
+                & $playwrightPs1.FullName install chromium
+              } else {
+                Write-Warning "playwright.ps1 not found — skipping browser install"
+              }
+            displayName: 'Install Playwright Chromium'
+
+          - task: DotNetCoreCLI@2
+            displayName: 'E2E Tests (Playwright)'
+            inputs:
+              command: 'test'
+              projects: 'tests/FlyITA.E2E.Tests/FlyITA.E2E.Tests.csproj'
+              arguments: '--configuration $(buildConfiguration) --no-build --logger trx --results-directory $(Agent.TempDirectory)/TestResults'
+            continueOnError: true
+
+          - task: DotNetCoreCLI@2
             displayName: 'Publish Web App'
             inputs:
               command: 'publish'


### PR DESCRIPTION
## Summary
- Add Playwright Chromium install step to both CI pipelines
- Run 40+ E2E tests after unit/integration tests
- `continueOnError: true` — E2E failures don't block the build (some tests may need a running server)

## Changes
- `azure-pipelines.yml` — build E2E project, install Chromium via `playwright.ps1`, run E2E tests
- `.github/workflows/ci.yml` — same pattern

## Test plan
- [x] Pipeline YAML syntax valid
- [ ] Azure DevOps pipeline runs E2E tests (needs agent with .NET 10 + Playwright)
- [ ] GitHub Actions runs E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)