### PR TITLE
feat: a11y tests, color contrast, CSS cleanup (#32, #33, #34)

### DIFF
--- a/src/FlyITA.Web/package.json
+++ b/src/FlyITA.Web/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "scripts": {
+    "css:purge": "purgecss --css wwwroot/css/theme.css wwwroot/css/main.css --content Pages/**/*.cshtml wwwroot/js/**/*.js --output wwwroot/css/purged/",
+    "css:analyze": "purgecss --css wwwroot/css/theme.css wwwroot/css/main.css --content Pages/**/*.cshtml wwwroot/js/**/*.js --rejected --output wwwroot/css/purged/"
+  },
+  "devDependencies": {
+    "purgecss": "^6.0.0"
+  }
+}

--- a/src/FlyITA.Web/wwwroot/css/main.css
+++ b/src/FlyITA.Web/wwwroot/css/main.css
@@ -65,52 +65,6 @@
     }
 }
 
-/*-------------------------------------------------------------------------------------------*/
-/*  Accordion Tab    ||---------------------------- */
-/*-------------------------------------------------------------------------------------------*/
-.accordion-section {
-    border-top: 1px solid #f1f1f1;
-    border-left: 1px solid #f1f1f1;
-    border-right: 1px solid #f1f1f1;
-}
-
-    .accordion-section:last-child {
-        border-bottom: 1px solid #f1f1f1;
-    }
-
-.accordion-title {
-    cursor: pointer;
-    display: block;
-    position: relative;
-    padding: 20px 20px;
-    margin: 0px;
-}
-
-    .accordion-title.active {
-        color: #b0df01;
-    }
-
-    .accordion-title:before {
-        content: "\f105";
-        display: block;
-        font-family: "Font Awesome 6 Free", sans-serif;
-        font-weight: 900;
-        position: absolute;
-        right: 18px;
-    }
-
-    .accordion-title.active:before {
-        content: "\f107";
-    }
-
-.accordion-content.default-hidden {
-    display: none;
-    margin: 0;
-}
-
-.accordion-content {
-    padding: 0 20px 10px;
-}
 
 /* =============================================================================================================================*/
 /* Parallax ------------------- */

--- a/src/FlyITA.Web/wwwroot/css/theme.css
+++ b/src/FlyITA.Web/wwwroot/css/theme.css
@@ -577,9 +577,6 @@ form {
   padding: 0;
   height: 100%;
 }
-.bootstrap-datetimepicker-widget {
-  background-color: #fff !important;
-}
 .pad-both {
   padding-top: 40px;
   padding-bottom: 40px;
@@ -856,31 +853,6 @@ body #wrapper .main-content div#profile-information {
 body #wrapper .main-content .highlight {
   font-weight: bold;
   color: #ad132b;
-}
-body #wrapper .main-content .embed-responsive {
-  position: relative;
-  display: block;
-  height: 0;
-  padding: 0;
-  overflow: hidden;
-}
-body #wrapper .main-content .embed-responsive .embed-responsive-item,
-body #wrapper .main-content .embed-responsive iframe,
-body #wrapper .main-content .embed-responsive embed,
-body #wrapper .main-content .embed-responsive object {
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  height: 100%;
-  width: 100%;
-  border: 0;
-}
-body #wrapper .main-content .embed-responsive.embed-responsive-16by9 {
-  padding-bottom: 56.25%;
-}
-body #wrapper .main-content .embed-responsive.embed-responsive-4by3 {
-  padding-bottom: 75%;
 }
 body footer.main-footer {
   height: auto;

--- a/tests/FlyITA.E2E.Tests/AxeAccessibilityTests.cs
+++ b/tests/FlyITA.E2E.Tests/AxeAccessibilityTests.cs
@@ -1,0 +1,59 @@
+using Deque.AxeCore.Playwright;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace FlyITA.E2E.Tests;
+
+public class AxeAccessibilityTests : IClassFixture<PlaywrightFixture>
+{
+    private readonly PlaywrightFixture _fixture;
+
+    public AxeAccessibilityTests(PlaywrightFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Theory]
+    [InlineData("/", "Home")]
+    [InlineData("/about", "About")]
+    [InlineData("/contact", "Contact")]
+    [InlineData("/privacy", "Privacy")]
+    [InlineData("/international", "International")]
+    [InlineData("/programs", "Programs")]
+    [InlineData("/reservations", "Reservations")]
+    [InlineData("/resources", "Resources")]
+    [InlineData("/travel-info", "TravelInfo")]
+    [InlineData("/guest-profile", "GuestProfile")]
+    [InlineData("/traveler-profile", "TravelerProfile")]
+    [InlineData("/vacation", "Vacation")]
+    [InlineData("/ach-payment", "AchPayment")]
+    [InlineData("/error", "Error")]
+    [InlineData("/thank-you", "ThankYou")]
+    [InlineData("/logout", "Logout")]
+    [InlineData("/access-denied", "AccessDenied")]
+    [InlineData("/closed", "Closed")]
+    public async Task Page_HasNoCriticalOrSeriousA11yViolations(string path, string pageName)
+    {
+        var page = await _fixture.Browser.NewPageAsync();
+        try
+        {
+            await page.GotoAsync($"{_fixture.BaseUrl}{path}");
+
+            var results = await page.RunAxe();
+
+            var critical = results.Violations.Where(v => v.Impact == "critical").ToList();
+            var serious = results.Violations.Where(v => v.Impact == "serious").ToList();
+
+            Assert.True(
+                critical.Count == 0,
+                $"{pageName}: {critical.Count} critical a11y violations: " +
+                string.Join(", ", critical.Select(v => $"{v.Id} ({v.Nodes.Count()} nodes)")));
+
+            Assert.True(
+                serious.Count == 0,
+                $"{pageName}: {serious.Count} serious a11y violations: " +
+                string.Join(", ", serious.Select(v => $"{v.Id} ({v.Nodes.Count()} nodes)")));
+        }
+        finally { await page.CloseAsync(); }
+    }
+}

--- a/tests/FlyITA.E2E.Tests/ColorContrastTests.cs
+++ b/tests/FlyITA.E2E.Tests/ColorContrastTests.cs
@@ -1,0 +1,45 @@
+using Deque.AxeCore.Playwright;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace FlyITA.E2E.Tests;
+
+public class ColorContrastTests : IClassFixture<PlaywrightFixture>
+{
+    private readonly PlaywrightFixture _fixture;
+
+    public ColorContrastTests(PlaywrightFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Theory]
+    [InlineData("/", "Home")]
+    [InlineData("/about", "About")]
+    [InlineData("/contact", "Contact")]
+    [InlineData("/guest-profile", "GuestProfile")]
+    [InlineData("/traveler-profile", "TravelerProfile")]
+    [InlineData("/vacation", "Vacation")]
+    [InlineData("/ach-payment", "AchPayment")]
+    public async Task Page_MeetsWCAG_AA_ColorContrast(string path, string pageName)
+    {
+        var page = await _fixture.Browser.NewPageAsync();
+        try
+        {
+            await page.GotoAsync($"{_fixture.BaseUrl}{path}");
+
+            var results = await page.RunAxe();
+
+            var contrastViolations = results.Violations
+                .Where(v => v.Id == "color-contrast")
+                .ToList();
+
+            Assert.True(
+                contrastViolations.Count == 0,
+                $"{pageName}: {contrastViolations.Sum(v => v.Nodes.Count())} elements fail WCAG AA color contrast. " +
+                string.Join("; ", contrastViolations.SelectMany(v => v.Nodes)
+                    .Select(n => n.Html?.Substring(0, Math.Min(n.Html?.Length ?? 0, 80)))));
+        }
+        finally { await page.CloseAsync(); }
+    }
+}

--- a/tests/FlyITA.E2E.Tests/FlyITA.E2E.Tests.csproj
+++ b/tests/FlyITA.E2E.Tests/FlyITA.E2E.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Deque.AxeCore.Playwright" Version="4.11.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Microsoft.Playwright" Version="1.58.0" />


### PR DESCRIPTION
## Summary
Closes #32, #33, #34 — all Track C (Accessibility & Polish)

### #32: axe-core a11y tests
- Added `Deque.AxeCore.Playwright` package
- 18 pages scanned for WCAG 2.1 AA critical/serious violations
- Tests run as part of E2E suite (Playwright required)

### #33: Color contrast tests
- 7 key pages tested for WCAG AA color-contrast rule via axe-core
- Fails if any element has insufficient contrast ratio (4.5:1 normal, 3:1 large)

### #34: CSS dead code removal
- Removed unused accordion section from main.css (not used in any page)
- Removed legacy `.bootstrap-datetimepicker-widget` from theme.css
- Removed Bootstrap 3 `.embed-responsive` polyfill (BS5 uses `.ratio`)
- Added `package.json` with PurgeCSS config for future full analysis

## Test plan
- [x] 285 non-E2E tests pass, 0 warnings
- [x] Build succeeds
- [ ] E2E + axe-core tests run when Playwright is installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)